### PR TITLE
Fix %patch macro for compatibility with RPM 4.20 and above

### DIFF
--- a/SPECS/kmod-drbd.spec
+++ b/SPECS/kmod-drbd.spec
@@ -1,7 +1,7 @@
 Name: kmod-drbd
 Summary: Kernel driver for DRBD
 Version: 9.2.16
-Release: 1.0%{?dist}
+Release: 1.1%{?dist}
 
 # always require a suitable userland
 Requires: drbd-utils >= 9.27.0
@@ -86,10 +86,7 @@ for the DRBD core and various transports.
 
 %prep
 rm -f %{?my_tmp_files_to_be_removed_in_prep}
-%setup -q -n drbd-%{tarball_version}
-%patch1001 -p1
-%patch1002 -p1
-%patch1003 -p1
+%autosetup -n drbd-%{tarball_version} -p1
 
 %build
 make -C drbd %{_smp_mflags} all KDIR=/lib/modules/%{kernel_version}/build \
@@ -173,6 +170,9 @@ sed -i "s/\# \(global_filter\)[[:space:]]*=.*/\1 = [ \"r|^\/dev\/drbd.*|\" ]/g" 
 rm -rf %{buildroot}
 
 %changelog
+* Wed May 06 2026 Vincent Michel <vincent.michel@vates.tech> - 9.2.16-1.1
+- Fix the %%patch macro in the specfile to be compatible with rpm 4.20 and above
+
 * Fri Jan 23 2026 Ronan Abhamon <ronan.abhamon@vates.tech> - 9.2.16-1.0
 - Remove 0003-drbd-drbd_md_get_buffer-do-not-give-up-early.patch
 - Add 0003-Fixup-for-recent-commit.patch


### PR DESCRIPTION
### Main information

#### Work Item Reference

XCPNG-3309 (previously XCPNG-2882)

#### Related changes

Similar PRs in:
- [libreswan](https://github.com/xcp-ng-rpms/libreswan/pull/3)
- [fuse](https://github.com/xcp-ng-rpms/fuse/pull/1)
- [drbd](https://github.com/xcp-ng-rpms/drbd/pull/10)
- [netdata](https://github.com/xcp-ng-rpms/netdata/pull/9)
- [slang](https://github.com/xcp-ng-rpms/slang/pull/3)
- [systemtap](https://github.com/xcp-ng-rpms/systemtap/pull/3)

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

Since [rpm 4.20.0]([https://rpm.org/releases/4.20.0](https://rpm.org/releases/4.20.0)
), the `%patchN` macro is no longer supported. This causes our `koji_build.py` script to fail if we happen to use rpm 4.20.0 or above (since the `specfile` python package is used to parse the RPM specfile). Here's the list of the affected repositories in [xcp-ng-rpms](https://github.com/xcp-ng-rpms):
- drbd
- fuse
- netdata
- slang
- systemtap


#### Release Target

- [ ] We already defined a release target with the release team.
- [ ] I haven't talked with the release team, but I have a proposed target.
- [x] I'm not sure, let's talk about it.

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->

---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

The users are not affected by this change.

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

No consequence on existing setups

#### Documentation update needed

- [ ] Yes
- [x] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->

<!-- Add links to the documentation update PRs if/when they are created. -->

N/A

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

None

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

The sources haven't changed, is testing necessary?

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->
I haven't checked yet

#### What tests have been or will be added to CI for this change? If none, explain why.

None

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [x] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->
