### PR TITLE
Release 9.2.18 + patches

### DIFF
--- a/SOURCES/0001-Revert-drbd-flush_send_buffer-send-error-should-resu.patch
+++ b/SOURCES/0001-Revert-drbd-flush_send_buffer-send-error-should-resu.patch
@@ -1,0 +1,84 @@
+From 956e4879de725f3271468b8077ff6839215fa130 Mon Sep 17 00:00:00 2001
+From: Joel Colledge <joel.colledge@linbit.com>
+Date: Thu, 9 Apr 2026 15:13:59 +0200
+Subject: [PATCH] Revert "drbd: flush_send_buffer: send error should result in
+ state change"
+
+This reverts commit 07742bcdc1179354c33197100aa14e8bf5897a67.
+
+The problem fixed by the above commit was also fixed by
+commit b29dba31e929 ("drbd: flush_send_buffer() result needs to be
+checked"), so reverting does not introduce a regression.
+
+Revert this commit because it caused a problem when the connection was
+lost at a particular moment, as described. S is the sender thread, R is
+the receiver thread.
+
+Initial steps:
+
+* S: Prepare header for P_DATA in `sbuf`, not sent because corked.
+* Connection lost.
+* S: Before sending data in `__send_bio`, call `flush_send_buffer`.
+  Connection lost so `conn( -> NetworkFailure)`.
+
+Now S enters a busy loop in `drbd_sender`:
+
+* Still bytes in `sbuf`, so `wait_for_sender_todo -> drbd_uncork ->
+  flush_send_buffer` changes `conn( -> NetworkFailure)`.
+* `wait_for_sender_todo` returns quickly although no todo because
+  `drbd_uncork` returns error.
+* `process_sender_todo` does nothing.
+
+This creates this loop:
+
+* R: `conn_disconnect` runs, changes `conn( -> Unconnected)`.
+* R restarts.
+* S: In busy loop changes `conn( -> NetworkFailure)`.
+* R: `conn_connect` fails to change `conn( -> Connecting)` because of
+  NetworkFailure state.
+
+The resulting logs look like this:
+
+drbd res peer: PingAck did not arrive in time.
+drbd res peer: conn( Connected -> NetworkFailure ) peer( Secondary -> Unknown )
+drbd res/0 drbd1 peer: pdsk( UpToDate -> DUnknown ) repl( Established -> Off )
+drbd res tcp:peer: dtt_send_page: size=40 len=40 sent=-4
+drbd res peer: Terminating sender thread
+drbd res peer: Starting sender thread (peer-node-id 1)
+drbd res/0 drbd1: new current UUID: D6391EA7BA692A99 weak: FFFFFFFFFFFFFFFA
+||:
+[Repeated section]
+drbd res peer: Connection closed
+drbd res peer: conn( NetworkFailure -> Unconnected ) [disconnected]
+drbd res peer: Restarting receiver thread
+drbd res peer: conn( Unconnected -> NetworkFailure )
+drbd res: State change failed: In transient state, retry after next state change (-18)
+drbd res peer: Failed: conn( NetworkFailure -> Connecting ) [connecting]
+drbd res peer: Terminating sender thread
+drbd res peer: Starting sender thread (peer-node-id 1)
+:||
+
+Depending on the timing in the environment, DRBD might escape from this
+loop quickly. However, it has been observed to continue for 1000s of
+iterations over many minutes.
+
+Signed-off-by: Joel Colledge <joel.colledge@linbit.com>
+---
+ drbd/drbd_main.c | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/drbd/drbd_main.c b/drbd/drbd_main.c
+index 5394db5e8..e684c5e7a 100644
+--- a/drbd/drbd_main.c
++++ b/drbd/drbd_main.c
+@@ -1026,9 +1026,7 @@ static int flush_send_buffer(struct drbd_connection *connection, enum drbd_strea
+ 		(sbuf->additional_size ? MSG_MORE : 0);
+ 	offset = sbuf->unsent - (char *)page_address(sbuf->page);
+ 	err = tr_ops->send_page(transport, drbd_stream, sbuf->page, offset, size, flags);
+-	if (err) {
+-		change_cstate(connection, C_NETWORK_FAILURE, CS_HARD);
+-	} else {
++	if (!err) {
+ 		sbuf->unsent =
+ 		sbuf->pos += sbuf->allocated_size;      /* send buffer submitted! */
+ 	}

--- a/SOURCES/0002-checkpatch-use-no-signoff-no-fixes-tag-for-merges.patch
+++ b/SOURCES/0002-checkpatch-use-no-signoff-no-fixes-tag-for-merges.patch
@@ -1,0 +1,46 @@
+From 062eb61f1cd7f8e5202d0d8d3099d7f40478ab0d Mon Sep 17 00:00:00 2001
+From: Joel Colledge <joel.colledge@linbit.com>
+Date: Mon, 13 Apr 2026 16:49:46 +0200
+Subject: [PATCH] checkpatch: use --no-signoff/--no-fixes-tag for merges
+
+Message formatting is still checked.
+
+Also skip 'fixup!' commits, which are temporary.
+
+Signed-off-by: Joel Colledge <joel.colledge@linbit.com>
+---
+ misc/checkpatch.sh | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/misc/checkpatch.sh b/misc/checkpatch.sh
+index b62104bbb..0c9c7ba94 100755
+--- a/misc/checkpatch.sh
++++ b/misc/checkpatch.sh
+@@ -73,7 +73,12 @@ message)
+ 	# line 3+ the body.
+ 	stripped=$(git stripspace --strip-comments < "$msgfile")
+ 	subject=$(echo "$stripped" | head -1)
++
++	# 'fixup' commits are temporary - do not check.
++	echo "$subject" | grep -qE '^fixup!' && exit 0
++
+ 	author=$(git var GIT_AUTHOR_IDENT | sed 's/> .*/>/')
++
+ 	{
+ 		echo "From: $author"
+ 		echo "Subject: [PATCH] $subject"
+@@ -83,7 +88,13 @@ message)
+ 		echo "diff --git a/x b/x"
+ 	} > "$patch"
+ 
+-	"$checkpatch" --no-tree --ignore FILE_PATH_CHANGES "$patch"
++	# Merge/Skip commits: check message formatting but not
++	# Signed-off-by or Fixes tags.
++	extra_args=()
++	echo "$subject" | grep -qE '^(Merge|Skip)' &&
++		extra_args=(--no-signoff --no-fixes-tag)
++
++	"$checkpatch" --no-tree --ignore FILE_PATH_CHANGES "${extra_args[@]}" "$patch"
+ 	;;
+ 
+ *)

--- a/SOURCES/0003-misc-add-prepare-commit-msg-script-to-add-signoff.patch
+++ b/SOURCES/0003-misc-add-prepare-commit-msg-script-to-add-signoff.patch
@@ -1,0 +1,46 @@
+From 12df60bc6ec2881a036a76a735341a1aa6ccaefa Mon Sep 17 00:00:00 2001
+From: Joel Colledge <joel.colledge@linbit.com>
+Date: Tue, 21 Apr 2026 13:42:21 +0200
+Subject: [PATCH] misc: add prepare-commit-msg script to add signoff
+
+Do not add signoff on merge commits.
+
+Signed-off-by: Joel Colledge <joel.colledge@linbit.com>
+---
+ README.md               |  2 +-
+ misc/prepare-commit-msg | 13 +++++++++++++
+ 2 files changed, 14 insertions(+), 1 deletion(-)
+ create mode 100755 misc/prepare-commit-msg
+
+diff --git a/README.md b/README.md
+index cc1bac04c..9ea49d314 100644
+--- a/README.md
++++ b/README.md
+@@ -29,7 +29,7 @@ curl -L https://github.com/torvalds/linux/raw/master/scripts/checkpatch.pl | sud
+ sudo chmod +x /usr/local/bin/checkpatch.pl
+ curl -L https://github.com/torvalds/linux/raw/master/scripts/spelling.txt | sudo tee /usr/local/bin/spelling.txt | wc
+ sudo echo > /usr/local/bin/const_structs.checkpatch
+-cp misc/pre-commit misc/commit-msg .git/hooks/
++cp misc/pre-commit misc/prepare-commit-msg misc/commit-msg .git/hooks/
+ ```
+ 
+ # Building DRBD
+diff --git a/misc/prepare-commit-msg b/misc/prepare-commit-msg
+new file mode 100755
+index 000000000..c0be8f66f
+--- /dev/null
++++ b/misc/prepare-commit-msg
+@@ -0,0 +1,13 @@
++#!/bin/sh
++
++NAME=$(git config user.name)
++EMAIL=$(git config user.email)
++
++[ -z "$NAME" ] && { echo "empty git config user.name"; exit 1; }
++[ -z "$EMAIL" ] && { echo "empty git config user.email"; exit 1; }
++
++[ "$2" = "merge" ] && exit 0
++
++git interpret-trailers --if-exists doNothing --trailer \
++    "Signed-off-by: $NAME <$EMAIL>" \
++    --in-place "$1"

--- a/SOURCES/0004-containers-add-Ubuntu-Resolute.patch
+++ b/SOURCES/0004-containers-add-Ubuntu-Resolute.patch
@@ -1,0 +1,57 @@
+From df38d2887517bb1891c33c6531f4aa750e04f54d Mon Sep 17 00:00:00 2001
+From: Roland Kammerer <roland.kammerer@linbit.com>
+Date: Tue, 28 Apr 2026 12:12:54 +0200
+Subject: [PATCH] containers: add Ubuntu Resolute
+
+Signed-off-by: Roland Kammerer <roland.kammerer@linbit.com>
+---
+ Makefile                   |  2 +-
+ docker/Dockerfile.resolute | 26 ++++++++++++++++++++++++++
+ 2 files changed, 27 insertions(+), 1 deletion(-)
+ create mode 100644 docker/Dockerfile.resolute
+
+diff --git a/Makefile b/Makefile
+index 9856907f6..0dfd102e5 100644
+--- a/Makefile
++++ b/Makefile
+@@ -31,7 +31,7 @@ ARCH ?= amd64
+ ifneq ($(strip $(ARCH)),)
+ DOCKERREGISTRY := $(DOCKERREGISTRY)/$(ARCH)
+ endif
+-DOCKERIMAGES = rhel7 rhel8 rhel9 rhel10 focal jammy noble flatcar amzn2 sles15
++DOCKERIMAGES = rhel7 rhel8 rhel9 rhel10 focal jammy noble resolute flatcar amzn2 sles15
+ DOCKERIMAGESTARGETS = $(addprefix dockerimage.,$(DOCKERIMAGES))
+ 
+ # Use the SPAAS (spatch as a service) online service
+diff --git a/docker/Dockerfile.resolute b/docker/Dockerfile.resolute
+new file mode 100644
+index 000000000..0c3e6fb40
+--- /dev/null
++++ b/docker/Dockerfile.resolute
+@@ -0,0 +1,26 @@
++FROM ubuntu:resolute
++
++RUN apt-get update && \
++	apt-get install -y \
++		curl \
++		diffutils \
++		elfutils \
++		gcc \
++		gnupg \
++		kmod \
++		make \
++		patch \
++		perl \
++		python3-setuptools \
++	&& \
++	apt-get clean && \
++	cd /tmp && \
++	curl -fsSL https://github.com/LINBIT/python-lbdist/archive/master.tar.gz | tar vxz && \
++	( cd python-lbdist-master && python3 setup.py install ) && \
++	rm -rf python-lbdist-master
++
++COPY /entry.sh /
++COPY /drbd.tar.gz /
++COPY /pkgs /pkgs
++
++ENTRYPOINT /entry.sh

--- a/SOURCES/0005-build-enable-fault-injection-using-ccflags-y.patch
+++ b/SOURCES/0005-build-enable-fault-injection-using-ccflags-y.patch
@@ -1,0 +1,29 @@
+From 7ed3bf75d58fceed253b2195c510fe8db3766645 Mon Sep 17 00:00:00 2001
+From: Joel Colledge <joel.colledge@linbit.com>
+Date: Wed, 6 May 2026 16:22:43 +0200
+Subject: [PATCH] build: enable fault injection using ccflags-y
+
+The approach using `override EXTRA_CFLAGS +=` does not work on some
+modern kernels. For instance 7.0.0-14-generic from Ubuntu Resolute /
+26.04.
+
+This is a partial backport of commit 4d2b2ac9e718 ("drbd: add fault
+injection and debugfs for bio chaining").
+
+Signed-off-by: Joel Colledge <joel.colledge@linbit.com>
+---
+ drbd/Kbuild.drbd | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drbd/Kbuild.drbd b/drbd/Kbuild.drbd
+index 39e32a2ee..b5fcc73e8 100644
+--- a/drbd/Kbuild.drbd
++++ b/drbd/Kbuild.drbd
+@@ -63,6 +63,7 @@ endif
+ # enable fault injection by default
+ ifndef CONFIG_DRBD_FAULT_INJECTION
+ 	override EXTRA_CFLAGS += -DCONFIG_DRBD_FAULT_INJECTION
++	ccflags-y += -DCONFIG_DRBD_FAULT_INJECTION
+ endif
+ 
+ # Disabled for the external module build by default.

--- a/SOURCES/0006-build-stamp-compat.h-against-include-config-auto.con.patch
+++ b/SOURCES/0006-build-stamp-compat.h-against-include-config-auto.con.patch
@@ -1,0 +1,49 @@
+From d8892467521c3406480fefcbd84cc57c1ded64b2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Christoph=20B=C3=B6hmwalder?=
+ <christoph.boehmwalder@linbit.com>
+Date: Mon, 11 May 2026 17:36:45 +0200
+Subject: [PATCH] build: stamp compat.h against include/config/auto.conf, not
+ .config
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Upstream Linux v6.12 commit aaed5c7739be ("kbuild: slim down package
+for building external modules") removed the explicit copy of .config
+into the linux-headers Debian package built by make bindeb-pkg. With
+that change, $(objtree)/.config is absent in installed headers for any
+kernel produced via stock bindeb-pkg, and the date -r / touch -r calls
+that drive the compat-h freshness check abort the build.
+
+include/config/auto.conf is regenerated from .config on every kconfig
+change, is part of the public kbuild interface, and is shipped by every
+kernel-headers package (Ubuntu, Debian, RHEL kernel-devel, and stock
+bindeb-pkg all include it). Use it as the freshness reference instead.
+
+Signed-off-by: Christoph Böhmwalder <christoph.boehmwalder@linbit.com>
+---
+ drbd/Kbuild | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drbd/Kbuild b/drbd/Kbuild
+index 80ec69dcc..a26e084d6 100644
+--- a/drbd/Kbuild
++++ b/drbd/Kbuild
+@@ -82,7 +82,7 @@ patch-target := $(obj)/dummy-for-patch.o
+ $(patch-target): $(obj)/dummy-for-compat-h.o
+ 	@true
+ 
+-ifneq ($(shell date -r $(objtree)/.config),$(shell date -r $(obj.build)/.config.timestamp 2> /dev/null))
++ifneq ($(shell date -r $(objtree)/include/config/auto.conf),$(shell date -r $(obj.build)/.config.timestamp 2> /dev/null))
+ COMPAT_FORCE := FORCE
+ endif
+ 
+@@ -137,7 +137,7 @@ filechk_compat.h = { printf '$(obj.build)/%s ' $(patsubst $(obj.build)/%,%,$(TES
+ 
+ $(compat.h): $(TEST_R) FORCE
+ 	$(call filechk,compat.h)
+-	$(Q)touch -r $(objtree)/.config $(obj.build)/.config.timestamp
++	$(Q)touch -r $(objtree)/include/config/auto.conf $(obj.build)/.config.timestamp
+ 
+ # Generate / find from cache the compat.patch.
+ # If we used an old compat.patch from the cache,

--- a/SOURCES/0007-drbd-prefer-exact-IP-port-match-in-drbd_find_path_by.patch
+++ b/SOURCES/0007-drbd-prefer-exact-IP-port-match-in-drbd_find_path_by.patch
@@ -1,0 +1,66 @@
+From 624e5e1585fc44a29a1ad00144551a8e02501259 Mon Sep 17 00:00:00 2001
+From: Joel Colledge <joel.colledge@linbit.com>
+Date: Mon, 11 May 2026 15:40:03 +0000
+Subject: [PATCH] drbd: prefer exact (IP, port) match in
+ drbd_find_path_by_addr()
+
+Consider the following configuration:
+* DRBD Nodes A, B, C
+* Dedicated DRBD proxy nodes P, Q
+* Direct connection A-B
+* Proxy connections A-P-Q-C and B-P-Q-C
+
+Now there are 2 connections "Q-C" from the proxy inside to DRBD. Prior
+to this change, if the same port is used on C for each of these
+connections, then DRBD on C cannot distinguish the incoming TCP
+connections. More generally, when two paths share the same listener and
+the same peer IP, the old IP-only lookup always returned the first
+matching path. Incoming sockets for the second path were then silently
+misrouted to the first, causing "Peer presented a node_id of X instead
+of Y" errors and wait-connect timeouts.
+
+When searching for the path for an incoming connection, prefer an exact
+(IP, port) match. A corresponding change to DRBD proxy causes it to bind
+outgoing inside connections to the configured port. The result is that
+DRBD can reliably distinguish the incoming connections. Direct
+DRBD-to-DRBD peers use an ephemeral source port so they continue to
+match via the IP-only fallback, preserving existing behaviour for all
+configurations.
+
+Signed-off-by: Joel Colledge <joel.colledge@linbit.com>
+---
+ drbd/drbd_transport.c | 17 +++++++++++++----
+ 1 file changed, 13 insertions(+), 4 deletions(-)
+
+diff --git a/drbd/drbd_transport.c b/drbd/drbd_transport.c
+index 7c6128cbb..f37ccd37b 100644
+--- a/drbd/drbd_transport.c
++++ b/drbd/drbd_transport.c
+@@ -266,14 +266,23 @@ void drbd_put_listener(struct drbd_path *path)
+ 
+ struct drbd_path *drbd_find_path_by_addr(struct drbd_listener *listener, struct sockaddr_storage *addr)
+ {
+-	struct drbd_path *path;
+-
++	struct drbd_path *path, *ip_match = NULL;
++
++	/*
++	 * Prefer an exact (IP, port) match. This disambiguates multiple paths
++	 * that share a peer IP but have distinct peer_addr ports, as long as
++	 * the peer (typically a DRBD proxy instance) binds its source port
++	 * accordingly. Direct DRBD-to-DRBD peers use an ephemeral source port
++	 * and are resolved by the first IP-only match.
++	 */
+ 	list_for_each_entry(path, &listener->waiters, listener_link) {
+-		if (addr_equal(&path->peer_addr, addr))
++		if (addr_and_port_equal(&path->peer_addr, addr))
+ 			return path;
++		if (!ip_match && addr_equal(&path->peer_addr, addr))
++			ip_match = path;
+ 	}
+ 
+-	return NULL;
++	return ip_match;
+ }
+ 
+ /**

--- a/SOURCES/0009-drbd-limit-number-of-volumes-resyncing-in-parallel.patch
+++ b/SOURCES/0009-drbd-limit-number-of-volumes-resyncing-in-parallel.patch
@@ -1,0 +1,478 @@
+From 0d2f376a7d72045a0ae9a8a577cde20bd7f889a9 Mon Sep 17 00:00:00 2001
+From: Philipp Reisner <philipp.reisner@linbit.com>
+Date: Mon, 4 May 2026 14:09:56 +0200
+Subject: [PATCH] drbd: limit number of volumes resyncing in parallel
+
+Today an arbitrary number of volumes can resync simultaneously, slicing
+disk and network bandwidth thinly across all of them. On a host with
+many volumes sharing the same physical disks or network link, total
+time-to-in-sync suffers.
+
+Introduce a runtime-changeable module parameter max_parallel_resyncs
+that caps how many volumes may have an unpaused resync (or verify) at
+any given time. The default of 0 preserves existing behaviour
+(unlimited). Counting is per-volume (struct drbd_device): multiple
+peer_devices of the same volume that resync in parallel still occupy
+a single slot. L_SYNC_S/T and L_VERIFY_S/T count toward the cap; their
+L_PAUSED_* counterparts do not.
+
+When admitting paused volumes, prefer volumes whose resource already
+has a running resync. That way we finish all volumes of one resource
+before starting volumes of the next, instead of spreading the resync
+of every resource thinly across the cluster.
+
+Reuse the existing resync-pause mechanism by adding a new pause-reason
+flag resync_susp_max_parallel[] alongside the existing user / peer /
+dependency / other_c flags. The flag plumbs through the state-change
+snapshot, the resync_suspended() aggregator that maps L_SYNC_* to
+L_PAUSED_SYNC_*, the change-detection notifier path, and the per-
+peer_device suspension-reason printer (shows "max_parallel,").
+
+Re-evaluation runs in three places: on every state change that
+finishes a resync (right next to the existing resume_next_sg() call),
+on every write to /sys/module/drbd/parameters/max_parallel_resyncs,
+and inline in drbd_start_resync() so the very first transition lands
+in L_PAUSED_SYNC_* instead of flicking through L_SYNC_* first.
+
+The flag is a local admission-control decision; it is not propagated
+to peers, so the wire protocol is unchanged. Each node makes its own
+admission decision based on its own max_parallel_resyncs.
+
+Signed-off-by: Philipp Reisner <philipp.reisner@linbit.com>
+---
+ drbd/drbd_int.h          |   3 +
+ drbd/drbd_main.c         |  20 +++++
+ drbd/drbd_sender.c       | 185 +++++++++++++++++++++++++++++++++++++++
+ drbd/drbd_state.c        |  44 +++++++++-
+ drbd/drbd_state.h        |   2 +
+ drbd/drbd_state_change.h |   1 +
+ 6 files changed, 251 insertions(+), 4 deletions(-)
+
+diff --git a/drbd/drbd_int.h b/drbd/drbd_int.h
+index d8af99572..7c46f9ee3 100644
+--- a/drbd/drbd_int.h
++++ b/drbd/drbd_int.h
+@@ -46,6 +46,7 @@
+ /* module parameter, defined in drbd_main.c */
+ extern unsigned int drbd_minor_count;
+ extern unsigned int drbd_protocol_version_min;
++extern unsigned int drbd_max_parallel_resyncs;
+ extern bool drbd_strict_names;
+ 
+ static inline bool drbd_protocol_version_acceptable(unsigned int pv)
+@@ -1333,6 +1334,7 @@ struct drbd_peer_device {
+ 	bool resync_susp_peer[2];
+ 	bool resync_susp_dependency[2];
+ 	bool resync_susp_other_c[2];
++	bool resync_susp_max_parallel[2];
+ 	bool resync_active[2];
+ 	enum drbd_repl_state negotiation_result; /* To find disk state after attach */
+ 	unsigned int send_cnt;
+@@ -2212,6 +2214,7 @@ void drbd_start_resync(struct drbd_peer_device *peer_device,
+ 		       enum drbd_repl_state side, const char *tag);
+ void resume_next_sg(struct drbd_device *device);
+ void suspend_other_sg(struct drbd_device *device);
++void drbd_apply_resync_max_parallel(void);
+ void drbd_resync_finished(struct drbd_peer_device *peer_device,
+ 			  enum drbd_disk_state new_peer_disk_state);
+ void verify_progress(struct drbd_peer_device *peer_device,
+diff --git a/drbd/drbd_main.c b/drbd/drbd_main.c
+index e684c5e7a..863ea464e 100644
+--- a/drbd/drbd_main.c
++++ b/drbd/drbd_main.c
+@@ -128,6 +128,26 @@ static const struct kernel_param_ops param_ops_drbd_protocol_version = {
+ 
+ unsigned int drbd_protocol_version_min = PRO_VERSION_8_MIN;
+ module_param_named(protocol_version_min, drbd_protocol_version_min, drbd_protocol_version, 0644);
++
++static int param_set_max_parallel_resyncs(const char *s, const struct kernel_param *kp)
++{
++	int rv = param_set_uint(s, kp);
++
++	if (rv == 0)
++		drbd_apply_resync_max_parallel();
++	return rv;
++}
++
++static const struct kernel_param_ops param_ops_max_parallel_resyncs = {
++	.set = param_set_max_parallel_resyncs,
++	.get = param_get_uint,
++};
++
++unsigned int drbd_max_parallel_resyncs;	/* 0 = unlimited */
++module_param_cb(max_parallel_resyncs, &param_ops_max_parallel_resyncs,
++		&drbd_max_parallel_resyncs, 0644);
++MODULE_PARM_DESC(max_parallel_resyncs,
++	"Cap on volumes resyncing in parallel (0 = unlimited)");
+ #define protocol_version_min_desc								\
+ 	"\n\t\tReject DRBD dialects older than this.\n\t\t"					\
+ 	"Supported: "										\
+diff --git a/drbd/drbd_sender.c b/drbd/drbd_sender.c
+index 2317e1df3..fba5d700e 100644
+--- a/drbd/drbd_sender.c
++++ b/drbd/drbd_sender.c
+@@ -2650,6 +2650,189 @@ void suspend_other_sg(struct drbd_device *device)
+ 	unlock_all_resources();
+ }
+ 
++static bool __device_is_resyncing(struct drbd_device *device)
++{
++	struct drbd_peer_device *peer_device;
++
++	for_each_peer_device_rcu(peer_device, device) {
++		enum drbd_repl_state s = peer_device->repl_state[NOW];
++
++		if (s == L_SYNC_SOURCE || s == L_SYNC_TARGET ||
++		    s == L_VERIFY_S || s == L_VERIFY_T)
++			return true;
++	}
++	return false;
++}
++
++static bool __resource_has_resyncing_device(struct drbd_resource *resource)
++{
++	struct drbd_device *device;
++	int vnr;
++
++	idr_for_each_entry(&resource->devices, device, vnr) {
++		if (__device_is_resyncing(device))
++			return true;
++	}
++	return false;
++}
++
++/* Only admit a device whose unblocking would actually transition it into
++ * L_SYNC_*. Otherwise the slot would be consumed without progress: e.g.,
++ * a volume blocked by both max_parallel and resync-after would stay
++ * paused on the dependency, starving the volume it is waiting for.
++ */
++static bool device_held_by_max_parallel(struct drbd_device *device)
++{
++	struct drbd_peer_device *peer_device;
++
++	for_each_peer_device_rcu(peer_device, device) {
++		enum drbd_repl_state s = peer_device->repl_state[NOW];
++
++		if ((s != L_PAUSED_SYNC_S && s != L_PAUSED_SYNC_T) ||
++		    !peer_device->resync_susp_max_parallel[NOW])
++			continue;
++
++		if (peer_device->resync_susp_user[NOW] ||
++		    peer_device->resync_susp_peer[NOW] ||
++		    peer_device->resync_susp_dependency[NOW] ||
++		    peer_device->resync_susp_other_c[NOW])
++			continue;
++
++		return true;
++	}
++	return false;
++}
++
++static bool set_suspend_resync_device_max_parallel(struct drbd_device *device, bool value)
++{
++	struct drbd_resource *resource = device->resource;
++	struct drbd_peer_device *peer_device;
++
++	begin_state_change_locked(resource, CS_HARD);
++	for_each_peer_device_rcu(peer_device, device) {
++		if (peer_device->resync_susp_max_parallel[NOW] != value)
++			__change_resync_susp_max_parallel(peer_device, value);
++	}
++	return end_state_change_locked(resource, "resync-max-parallel") != SS_NOTHING_TO_DO;
++}
++
++/* Re-evaluate the parallel-resync limit across all volumes and toggle
++ * resync_susp_max_parallel to enforce drbd_max_parallel_resyncs. limit == 0
++ * means unlimited (clear all max_parallel suspensions).
++ */
++void drbd_apply_resync_max_parallel(void)
++{
++	unsigned int limit = READ_ONCE(drbd_max_parallel_resyncs);
++	struct drbd_resource *resource;
++	struct drbd_device *device;
++	unsigned int running = 0;
++	int vnr;
++
++	lock_all_resources();
++	rcu_read_lock();
++
++	if (limit == 0) {
++		for_each_resource_rcu(resource, &drbd_resources) {
++			idr_for_each_entry(&resource->devices, device, vnr)
++				set_suspend_resync_device_max_parallel(device, false);
++		}
++		goto out;
++	}
++
++	for_each_resource_rcu(resource, &drbd_resources) {
++		idr_for_each_entry(&resource->devices, device, vnr) {
++			if (__device_is_resyncing(device))
++				running++;
++		}
++	}
++
++	if (running > limit) {
++		unsigned int excess = running - limit;
++
++		for_each_resource_rcu(resource, &drbd_resources) {
++			if (excess == 0)
++				break;
++			idr_for_each_entry(&resource->devices, device, vnr) {
++				if (excess == 0)
++					break;
++				if (__device_is_resyncing(device)) {
++					if (set_suspend_resync_device_max_parallel(device, true))
++						excess--;
++				}
++			}
++		}
++	} else if (running < limit) {
++		unsigned int slots = limit - running;
++
++		/* Pass 1: top up resources that already have a running resync,
++		 * so we finish all volumes of one resource before starting
++		 * volumes of the next.
++		 */
++		for_each_resource_rcu(resource, &drbd_resources) {
++			if (slots == 0)
++				break;
++			if (!__resource_has_resyncing_device(resource))
++				continue;
++			idr_for_each_entry(&resource->devices, device, vnr) {
++				if (slots == 0)
++					break;
++				if (device_held_by_max_parallel(device)) {
++					if (set_suspend_resync_device_max_parallel(device, false))
++						slots--;
++				}
++			}
++		}
++
++		/* Pass 2: any remaining slots go to volumes of fresh
++		 * resources.
++		 */
++		for_each_resource_rcu(resource, &drbd_resources) {
++			if (slots == 0)
++				break;
++			idr_for_each_entry(&resource->devices, device, vnr) {
++				if (slots == 0)
++					break;
++				if (device_held_by_max_parallel(device)) {
++					if (set_suspend_resync_device_max_parallel(device, false))
++						slots--;
++				}
++			}
++		}
++	}
++
++out:
++	rcu_read_unlock();
++	unlock_all_resources();
++}
++
++/* Caller already holds lock_all_resources(). Returns true if @device is
++ * allowed to start a new resync under the parallel-resync limit.
++ */
++static bool __device_max_parallel_admit(struct drbd_device *device)
++{
++	unsigned int limit = READ_ONCE(drbd_max_parallel_resyncs);
++	struct drbd_resource *resource;
++	struct drbd_device *d;
++	unsigned int running = 0;
++	int vnr;
++
++	if (limit == 0)
++		return true;
++
++	if (__device_is_resyncing(device))
++		return true;	/* already counted */
++
++	for_each_resource_rcu(resource, &drbd_resources) {
++		idr_for_each_entry(&resource->devices, d, vnr) {
++			if (d == device)
++				continue;
++			if (__device_is_resyncing(d))
++				running++;
++		}
++	}
++	return running < limit;
++}
++
+ /* caller must hold resources_mutex */
+ enum drbd_ret_code drbd_resync_after_valid(struct drbd_device *device, int resync_after)
+ {
+@@ -2936,6 +3119,8 @@ skip_helper:
+ 
+ 	begin_state_change_locked(device->resource, CS_VERBOSE);
+ 	__change_resync_susp_dependency(peer_device, !__drbd_may_sync_now(peer_device));
++	__change_resync_susp_max_parallel(peer_device,
++					  !__device_max_parallel_admit(device));
+ 	__change_repl_state(peer_device, side);
+ 	if (side == L_SYNC_TARGET)
+ 		init_resync_stable_bits(peer_device);
+diff --git a/drbd/drbd_state.c b/drbd/drbd_state.c
+index 0fca285fc..ac4409197 100644
+--- a/drbd/drbd_state.c
++++ b/drbd/drbd_state.c
+@@ -376,6 +376,9 @@ struct drbd_state_change *remember_state_change(struct drbd_resource *resource,
+ 			memcpy(peer_device_state_change->resync_susp_other_c,
+ 			       peer_device->resync_susp_other_c,
+ 			       sizeof(peer_device->resync_susp_other_c));
++			memcpy(peer_device_state_change->resync_susp_max_parallel,
++			       peer_device->resync_susp_max_parallel,
++			       sizeof(peer_device->resync_susp_max_parallel));
+ 			memcpy(peer_device_state_change->resync_active,
+ 			       peer_device->resync_active,
+ 			       sizeof(peer_device->resync_active));
+@@ -462,6 +465,7 @@ void copy_old_to_new_state_change(struct drbd_state_change *state_change)
+ 		OLD_TO_NEW(p->resync_susp_peer);
+ 		OLD_TO_NEW(p->resync_susp_dependency);
+ 		OLD_TO_NEW(p->resync_susp_other_c);
++		OLD_TO_NEW(p->resync_susp_max_parallel);
+ 		OLD_TO_NEW(p->resync_active);
+ 	}
+ 
+@@ -547,6 +551,8 @@ static bool state_has_changed(struct drbd_resource *resource)
+ 				peer_device->resync_susp_dependency[NEW] ||
+ 			    peer_device->resync_susp_other_c[OLD] !=
+ 				peer_device->resync_susp_other_c[NEW] ||
++			    peer_device->resync_susp_max_parallel[OLD] !=
++				peer_device->resync_susp_max_parallel[NEW] ||
+ 			    peer_device->resync_active[OLD] !=
+ 				peer_device->resync_active[NEW] ||
+ 			    peer_device->uuid_flags & UUID_FLAG_GOT_STABLE)
+@@ -592,6 +598,8 @@ static void ___begin_state_change(struct drbd_resource *resource)
+ 				peer_device->resync_susp_dependency[NOW];
+ 			peer_device->resync_susp_other_c[NEW] =
+ 				peer_device->resync_susp_other_c[NOW];
++			peer_device->resync_susp_max_parallel[NEW] =
++				peer_device->resync_susp_max_parallel[NOW];
+ 			peer_device->resync_active[NEW] =
+ 				peer_device->resync_active[NOW];
+ 		}
+@@ -866,6 +874,8 @@ static enum drbd_state_rv ___end_state_change(struct drbd_resource *resource, st
+ 				peer_device->resync_susp_dependency[NEW];
+ 			peer_device->resync_susp_other_c[NOW] =
+ 				peer_device->resync_susp_other_c[NEW];
++			peer_device->resync_susp_max_parallel[NOW] =
++				peer_device->resync_susp_max_parallel[NEW];
+ 			peer_device->resync_active[NOW] =
+ 				peer_device->resync_active[NEW];
+ 		}
+@@ -1110,6 +1120,7 @@ static bool resync_suspended(struct drbd_peer_device *peer_device, enum which_st
+ {
+ 	return peer_device->resync_susp_user[which] ||
+ 	       peer_device->resync_susp_peer[which] ||
++	       peer_device->resync_susp_max_parallel[which] ||
+ 	       resync_susp_comb_dep(peer_device, which);
+ }
+ 
+@@ -1131,6 +1142,8 @@ static int scnprintf_resync_suspend_flags(char *buffer, size_t size,
+ 		b += scnprintf(b, end - b, "after dependency,");
+ 	if (peer_device->resync_susp_other_c[which])
+ 		b += scnprintf(b, end - b, "connection dependency,");
++	if (peer_device->resync_susp_max_parallel[which])
++		b += scnprintf(b, end - b, "max-parallel,");
+ 	if (is_sync_source_state(peer_device, which) && device->disk_state[which] <= D_INCONSISTENT)
+ 		b += scnprintf(b, end - b, "disk inconsistent,");
+ 
+@@ -1929,7 +1942,8 @@ static bool drbd_is_sync_target_candidate(struct drbd_peer_device *peer_device)
+ 
+ 	if (peer_device->resync_susp_dependency[NEW] ||
+ 			peer_device->resync_susp_peer[NEW] ||
+-			peer_device->resync_susp_user[NEW])
++			peer_device->resync_susp_user[NEW] ||
++			peer_device->resync_susp_max_parallel[NEW])
+ 		return false;
+ 
+ 	if (peer_device->disk_state[NEW] < D_OUTDATED)
+@@ -3513,7 +3527,8 @@ static void notify_state_change(struct drbd_state_change *state_change)
+ 		    HAS_CHANGED(p->resync_susp_user) ||
+ 		    HAS_CHANGED(p->resync_susp_peer) ||
+ 		    HAS_CHANGED(p->resync_susp_dependency) ||
+-		    HAS_CHANGED(p->resync_susp_other_c))
++		    HAS_CHANGED(p->resync_susp_other_c) ||
++		    HAS_CHANGED(p->resync_susp_max_parallel))
+ 			REMEMBER_STATE_CHANGE(notify_peer_device_state_change,
+ 					      p, NOTIFY_CHANGE);
+ 	}
+@@ -3914,6 +3929,8 @@ static int w_after_state_change(struct drbd_work *w, int unused)
+ 			bool *resync_susp_user = peer_device_state_change->resync_susp_user;
+ 			bool *resync_susp_peer = peer_device_state_change->resync_susp_peer;
+ 			bool *resync_susp_dependency = peer_device_state_change->resync_susp_dependency;
++			bool *resync_susp_max_parallel =
++				peer_device_state_change->resync_susp_max_parallel;
+ 			union drbd_state new_state =
+ 				state_change_word(state_change, n_device, n_connection, NEW);
+ 			bool send_uuids, send_state = false;
+@@ -4016,7 +4033,8 @@ static int w_after_state_change(struct drbd_work *w, int unused)
+ 			if (repl_state[NEW] >= L_ESTABLISHED &&
+ 			    ((resync_susp_comb_dep_sc(state_change, n_device, n_connection, OLD) !=
+ 			      resync_susp_comb_dep_sc(state_change, n_device, n_connection, NEW)) ||
+-			     (resync_susp_user[OLD] != resync_susp_user[NEW])))
++			     (resync_susp_user[OLD] != resync_susp_user[NEW]) ||
++			     (resync_susp_max_parallel[OLD] != resync_susp_max_parallel[NEW])))
+ 				send_state = true;
+ 
+ 			/* finished resync, tell sync source */
+@@ -4066,9 +4084,21 @@ static int w_after_state_change(struct drbd_work *w, int unused)
+ 			/* A resync finished or aborted, wake paused devices... */
+ 			if ((repl_state[OLD] > L_ESTABLISHED && repl_state[NEW] <= L_ESTABLISHED) ||
+ 			    (resync_susp_peer[OLD] && !resync_susp_peer[NEW]) ||
+-			    (resync_susp_user[OLD] && !resync_susp_user[NEW]))
++			    (resync_susp_user[OLD] && !resync_susp_user[NEW])) {
+ 				/* ldev_safe: ref from extra_ldev_ref_for_after_state_chg() */
+ 				resume_next_sg(device);
++				drbd_apply_resync_max_parallel();
++			} else {
++				enum drbd_repl_state old = repl_state[OLD];
++				enum drbd_repl_state new = repl_state[NEW];
++
++				/* A resync got paused; re-evaluate max_parallel_resyncs. */
++				if ((old == L_SYNC_SOURCE || old == L_SYNC_TARGET ||
++				     old == L_VERIFY_S || old == L_VERIFY_T) &&
++				    !(new == L_SYNC_SOURCE || new == L_SYNC_TARGET ||
++				      new == L_VERIFY_S || new == L_VERIFY_T))
++					drbd_apply_resync_max_parallel();
++			}
+ 
+ 			/* sync target done with resync. Explicitly notify all peers. Our sync
+ 			   source should even know by himself, but the others need that info. */
+@@ -6134,6 +6164,12 @@ void __change_resync_susp_dependency(struct drbd_peer_device *peer_device,
+ 	peer_device->resync_susp_dependency[NEW] = value;
+ }
+ 
++void __change_resync_susp_max_parallel(struct drbd_peer_device *peer_device,
++				       bool value)
++{
++	peer_device->resync_susp_max_parallel[NEW] = value;
++}
++
+ static void log_current_uuids(struct drbd_device *device)
+ {
+ 	struct drbd_peer_device *peer_device;
+diff --git a/drbd/drbd_state.h b/drbd/drbd_state.h
+index 241cf0929..2aa314f69 100644
+--- a/drbd/drbd_state.h
++++ b/drbd/drbd_state.h
+@@ -167,6 +167,8 @@ void __change_resync_susp_peer(struct drbd_peer_device *peer_device,
+ 			       bool value);
+ void __change_resync_susp_dependency(struct drbd_peer_device *peer_device,
+ 				     bool value);
++void __change_resync_susp_max_parallel(struct drbd_peer_device *peer_device,
++				       bool value);
+ void apply_connect(struct drbd_connection *connection, bool commit);
+ 
+ struct drbd_work;
+diff --git a/drbd/drbd_state_change.h b/drbd/drbd_state_change.h
+index 02675e206..d04dd7e59 100644
+--- a/drbd/drbd_state_change.h
++++ b/drbd/drbd_state_change.h
+@@ -42,6 +42,7 @@ struct drbd_peer_device_state_change {
+ 	bool resync_susp_peer[2];
+ 	bool resync_susp_dependency[2];
+ 	bool resync_susp_other_c[2];
++	bool resync_susp_max_parallel[2];
+ 	bool resync_active[2];
+ };
+ 

--- a/SOURCES/0010-drbd-fix-AB-BA-deadlock-between-online-resize-and-AL.patch
+++ b/SOURCES/0010-drbd-fix-AB-BA-deadlock-between-online-resize-and-AL.patch
@@ -1,0 +1,105 @@
+From 1432b01ffcc151903a89f4624885e24d8305d122 Mon Sep 17 00:00:00 2001
+From: Philipp Reisner <philipp.reisner@linbit.com>
+Date: Thu, 14 May 2026 22:30:54 +0200
+Subject: [PATCH] drbd: fix AB-BA deadlock between online resize and AL
+ transactions
+
+drbd_determine_dev_size() acquired md_buffer first and then the AL
+transaction lock, while al_write_transaction() (reached from peer
+requests via drbd_al_begin_io_commit()) acquired them in the opposite
+order.  Running concurrently the two callers can deadlock: the resize
+thread holds md_buffer and waits for the AL transaction lock; the AL
+committer holds the AL transaction lock and waits for md_buffer.  In
+the field this manifested as drbdsetup resize hanging indefinitely
+inside drbd_determine_dev_size() and the corresponding submit worker
+stuck in drbd_md_get_buffer() inside al_write_transaction().
+
+Fix this by taking the AL transaction lock in drbd_determine_dev_size()
+before drbd_md_get_buffer(), matching the ordering used everywhere
+else, and release both on every exit path.
+
+Fixes: 08050c71eb04 ("drbd: Allow online change of al-stripes and al-stripe-size")
+Co-developed-by: Joel Colledge <joel.colledge@linbit.com>
+Signed-off-by: Joel Colledge <joel.colledge@linbit.com>
+Signed-off-by: Philipp Reisner <philipp.reisner@linbit.com>
+---
+ drbd/drbd_nl.c | 32 ++++++++++++++++----------------
+ 1 file changed, 16 insertions(+), 16 deletions(-)
+
+diff --git a/drbd/drbd_nl.c b/drbd/drbd_nl.c
+index adea74a37..b932c0620 100644
+--- a/drbd/drbd_nl.c
++++ b/drbd/drbd_nl.c
+@@ -1633,8 +1633,16 @@ drbd_determine_dev_size(struct drbd_device *device, sector_t peer_current_size,
+ 	 * data in core memory, to "move" it we just write it all out, there
+ 	 * are no reads. */
+ 	drbd_suspend_io(device, READ_AND_WRITE);
++
++	/* Take the AL transaction lock before the md_buffer to avoid an
++	 * AB-BA deadlock against al_write_transaction().
++	 */
++	wait_event(device->al_wait, drbd_al_try_lock_for_transaction(device));
++
+ 	buffer = drbd_md_get_buffer(device, __func__); /* Lock meta-data IO */
+ 	if (!buffer) {
++		lc_unlock(device->act_log);
++		wake_up(&device->al_wait);
+ 		drbd_resume_io(device);
+ 		return DS_ERROR;
+ 	}
+@@ -1649,8 +1657,13 @@ drbd_determine_dev_size(struct drbd_device *device, sector_t peer_current_size,
+ 	prev.al_stripe_size_4k = md->al_stripe_size_4k;
+ 	prev_size = get_capacity(device->vdisk);
+ 
++	/* We do some synchronous IO below, which may take some time.
++	 * Clear the timer, to avoid scary "timer expired!" messages,
++	 * "Superblock" is written out at least twice below, anyways.
++	 */
++	timer_delete(&device->md_sync_timer);
++
+ 	if (rs) {
+-		/* FIXME race with peer requests that want to do an AL transaction */
+ 		/* rs is non NULL if we should change the AL layout only */
+ 		md->al_stripes = rs->al_stripes;
+ 		md->al_stripe_size_4k = rs->al_stripe_size / 4;
+@@ -1721,21 +1734,9 @@ drbd_determine_dev_size(struct drbd_device *device, sector_t peer_current_size,
+ 		bool prev_al_disabled = 0;
+ 		u32 prev_peer_full_sync = 0;
+ 
+-		/* We do some synchronous IO below, which may take some time.
+-		 * Clear the timer, to avoid scary "timer expired!" messages,
+-		 * "Superblock" is written out at least twice below, anyways. */
+-		timer_delete(&device->md_sync_timer);
+-
+-		/* We won't change the "al-extents" setting, we just may need
+-		 * to move the on-disk location of the activity log ringbuffer.
+-		 * Lock for transaction is good enough, it may well be "dirty"
+-		 * or even "starving". */
+-		wait_event(device->al_wait, drbd_al_try_lock_for_transaction(device));
+-
+ 		if (drbd_md_dax_active(device->ldev)) {
+ 			if (drbd_dax_map(device->ldev)) {
+ 				drbd_err(device, "Could not remap DAX; aborting resize\n");
+-				lc_unlock(device->act_log);
+ 				goto err_out;
+ 			}
+ 		}
+@@ -1781,9 +1782,6 @@ drbd_determine_dev_size(struct drbd_device *device, sector_t peer_current_size,
+ 		if (rs)
+ 			drbd_info(device, "Changed AL layout to al-stripes = %d, al-stripe-size-kB = %d\n",
+ 				 md->al_stripes, md->al_stripe_size_4k * 4);
+-
+-		lc_unlock(device->act_log);
+-		wake_up(&device->al_wait);
+ 	}
+ 
+ 	if (size > prev_size)
+@@ -1804,6 +1802,8 @@ drbd_determine_dev_size(struct drbd_device *device, sector_t peer_current_size,
+ 		md->al_size_4k = (u64)prev.al_stripes * prev.al_stripe_size_4k;
+ 	}
+ 	drbd_md_put_buffer(device);
++	lc_unlock(device->act_log);
++	wake_up(&device->al_wait);
+ 	drbd_resume_io(device);
+ 
+ 	return rv;

--- a/SOURCES/0011-drbd-fix-list-corruption-when-freeing-peer_req-from-.patch
+++ b/SOURCES/0011-drbd-fix-list-corruption-when-freeing-peer_req-from-.patch
@@ -1,0 +1,81 @@
+From d7eea74d67e5909450bd8555597c9a143f22fbc3 Mon Sep 17 00:00:00 2001
+From: Philipp Reisner <philipp.reisner@linbit.com>
+Date: Thu, 14 May 2026 23:58:16 +0200
+Subject: [PATCH] drbd: fix list corruption when freeing peer_req from send_oos
+ list
+
+When got_peer_ack() splices a peer_request from connection->peer_requests
+onto peer_ack_connection->send_oos via drbd_queue_send_out_of_sync(), the
+EE_ON_RECV_ORDER flag is not cleared. That flag was originally a
+1:1 marker for membership in connection->peer_requests, which is
+protected by connection->peer_reqs_lock; send_oos is a different list,
+protected by send_oos_lock.
+
+drbd_send_oos_from() then iterates send_oos in parallel from multiple
+sender threads (one per oos_node_id), each clearing its bit in
+send_oos_pending. The last sender that drives send_oos_pending to zero
+calls drbd_free_peer_req() outside send_oos_lock.
+drbd_free_peer_req() sees EE_ON_RECV_ORDER set, takes peer_reqs_lock,
+and list_del's a node that is actually linked on send_oos. Concurrent
+operations on send_oos under send_oos_lock (other senders, or
+list_splice_tail() in drbd_queue_send_out_of_sync()) then corrupt the
+list:
+
+  list_del corruption. next->prev should be ..., but was ...
+  kernel BUG at lib/list_debug.c:65!
+   ? drbd_free_peer_req+0xe2/0x1b0 [drbd]
+   drbd_send_out_of_sync_wf+0x1be/0x260 [drbd]
+   drbd_sender+0x166/0x510 [drbd]
+
+Fix this by removing the peer_request from send_oos and clearing
+EE_ON_RECV_ORDER in drbd_send_oos_from(), under send_oos_lock, before
+calling drbd_free_peer_req(). Call drbd_send_oos_next_req() before the
+list_del so the iteration anchor stays on the list while the next
+position is computed.
+
+Fixes: 31f14b906312 ("drbd: send P_OUT_OF_SYNC after P_PEER_ACK in parallel")
+Co-developed-by: Joel Colledge <joel.colledge@linbit.com>
+Signed-off-by: Joel Colledge <joel.colledge@linbit.com>
+Signed-off-by: Philipp Reisner <philipp.reisner@linbit.com>
+---
+ drbd/drbd_receiver.c | 19 ++++++++++++-------
+ 1 file changed, 12 insertions(+), 7 deletions(-)
+
+diff --git a/drbd/drbd_receiver.c b/drbd/drbd_receiver.c
+index c5fafe2dd..e8b18ab50 100644
+--- a/drbd/drbd_receiver.c
++++ b/drbd/drbd_receiver.c
+@@ -11011,21 +11011,26 @@ static void drbd_send_oos_from(struct drbd_connection *oos_connection, int peer_
+ 	while (peer_req) {
+ 		struct drbd_peer_device *peer_device =
+ 			conn_peer_device(oos_connection, peer_req->peer_device->device->vnr);
+-		struct drbd_peer_request *free_peer_req = NULL;
++		struct drbd_peer_request *next_peer_req;
++		bool free_it;
+ 
+ 		/* Ignore errors and keep iterating to clear up list */
+ 		drbd_send_out_of_sync(peer_device, peer_req->i.sector, peer_req->i.size);
+ 
+ 		spin_lock_irq(&peer_ack_connection->send_oos_lock);
+ 		peer_req->send_oos_pending &= ~NODE_MASK(oos_node_id);
+-		if (!peer_req->send_oos_pending)
+-			free_peer_req = peer_req;
+-
+-		peer_req = drbd_send_oos_next_req(peer_ack_connection, oos_node_id, peer_req);
++		next_peer_req = drbd_send_oos_next_req(peer_ack_connection, oos_node_id, peer_req);
++		free_it = !peer_req->send_oos_pending;
++		if (free_it) {
++			peer_req->flags &= ~EE_ON_RECV_ORDER;
++			list_del(&peer_req->recv_order);
++		}
+ 		spin_unlock_irq(&peer_ack_connection->send_oos_lock);
+ 
+-		if (free_peer_req)
+-			drbd_free_peer_req(free_peer_req);
++		if (free_it)
++			drbd_free_peer_req(peer_req);
++
++		peer_req = next_peer_req;
+ 	}
+ 
+ 	kref_debug_put(&peer_ack_connection->kref_debug, 18);

--- a/SOURCES/0012-drbd-distinguish-send_oos-list-membership-with-EE_ON.patch
+++ b/SOURCES/0012-drbd-distinguish-send_oos-list-membership-with-EE_ON.patch
@@ -1,0 +1,84 @@
+From 198d4ebdaa12c19ffb5660432d91e7f9a35da686 Mon Sep 17 00:00:00 2001
+From: Philipp Reisner <philipp.reisner@linbit.com>
+Date: Mon, 18 May 2026 10:49:30 +0200
+Subject: [PATCH] drbd: distinguish send_oos list membership with
+ EE_ON_SEND_OOS
+
+Peer_requests on peer_req->recv_order can be linked on four different
+lists: connection->peer_requests, connection->peer_reads, and
+peer_device->resync_requests, and connection->send_oos.
+EE_ON_RECV_ORDER carried the membership marker for all four.
+
+Introduce EE_ON_SEND_OOS to specifically mark membership on send_oos.
+
+EE_ON_RECV_ORDER keeps its meaning, now narrowed to membership on a
+list protected by connection->peer_reqs_lock.
+
+Signed-off-by: Philipp Reisner <philipp.reisner@linbit.com>
+---
+ drbd/drbd_int.h      |  6 +++++-
+ drbd/drbd_receiver.c | 12 ++++++++----
+ 2 files changed, 13 insertions(+), 5 deletions(-)
+
+diff --git a/drbd/drbd_int.h b/drbd/drbd_int.h
+index 7c46f9ee3..868b30492 100644
+--- a/drbd/drbd_int.h
++++ b/drbd/drbd_int.h
+@@ -538,8 +538,11 @@ enum {
+ 	/* SyncTarget: This is the last resync request. */
+ 	__EE_LAST_RESYNC_REQUEST,
+ 
+-	/* This peer_req->recv_order is on some list */
++	/* This peer_req->recv_order is on some list protected by peer_reqs_lock */
+ 	__EE_ON_RECV_ORDER,
++
++	/* This peer_req->recv_order is on connection->send_oos protocted by send_oos_lock */
++	__EE_ON_SEND_OOS,
+ };
+ #define EE_MAY_SET_IN_SYNC     (1<<__EE_MAY_SET_IN_SYNC)
+ #define EE_SET_OUT_OF_SYNC     (1<<__EE_SET_OUT_OF_SYNC)
+@@ -556,6 +559,7 @@ enum {
+ #define EE_IN_ACTLOG		(1<<__EE_IN_ACTLOG)
+ #define EE_LAST_RESYNC_REQUEST	(1<<__EE_LAST_RESYNC_REQUEST)
+ #define EE_ON_RECV_ORDER	(1<<__EE_ON_RECV_ORDER)
++#define EE_ON_SEND_OOS		(1<<__EE_ON_SEND_OOS)
+ 
+ /* flag bits per device */
+ enum device_flag {
+diff --git a/drbd/drbd_receiver.c b/drbd/drbd_receiver.c
+index e8b18ab50..953411f1e 100644
+--- a/drbd/drbd_receiver.c
++++ b/drbd/drbd_receiver.c
+@@ -457,7 +457,7 @@ void drbd_free_peer_req(struct drbd_peer_request *peer_req)
+ 			list_del(&peer_req->recv_order);
+ 		spin_unlock_irq(&connection->peer_reqs_lock);
+ 	}
+-
++	D_ASSERT(peer_device, !(peer_req->flags & EE_ON_SEND_OOS));
+ 	if (peer_req->flags & EE_HAS_DIGEST)
+ 		kfree(peer_req->digest);
+ 	D_ASSERT(peer_device, atomic_read(&peer_req->pending_bios) == 0);
+@@ -11022,7 +11022,7 @@ static void drbd_send_oos_from(struct drbd_connection *oos_connection, int peer_
+ 		next_peer_req = drbd_send_oos_next_req(peer_ack_connection, oos_node_id, peer_req);
+ 		free_it = !peer_req->send_oos_pending;
+ 		if (free_it) {
+-			peer_req->flags &= ~EE_ON_RECV_ORDER;
++			peer_req->flags &= ~EE_ON_SEND_OOS;
+ 			list_del(&peer_req->recv_order);
+ 		}
+ 		spin_unlock_irq(&peer_ack_connection->send_oos_lock);
+@@ -11154,8 +11154,12 @@ found:
+ 
+ 		peer_req->send_oos_pending = drbd_calculate_send_oos_pending(device, in_sync);
+ 		any_send_oos_pending |= peer_req->send_oos_pending;
+-		if (!peer_req->send_oos_pending)
+-			drbd_free_peer_req(peer_req);
++		if (peer_req->send_oos_pending) {
++			peer_req->flags &= ~EE_ON_RECV_ORDER;
++			peer_req->flags |= EE_ON_SEND_OOS;
++		} else {
++			drbd_free_peer_req(peer_req); /* list_del() because EE_ON_RECV_ORDER */
++		}
+ 	}
+ 
+ 	drbd_queue_send_out_of_sync(connection, &work_list, any_send_oos_pending);

--- a/SOURCES/0013-Revert-drbd-prefer-exact-IP-port-match-in-drbd_find_.patch
+++ b/SOURCES/0013-Revert-drbd-prefer-exact-IP-port-match-in-drbd_find_.patch
@@ -1,0 +1,50 @@
+From f1d6d44889b7884c035af02ad6cbc1a77ff74251 Mon Sep 17 00:00:00 2001
+From: Joel Colledge <joel.colledge@linbit.com>
+Date: Wed, 13 May 2026 10:36:00 +0200
+Subject: [PATCH] Revert "drbd: prefer exact (IP, port) match in
+ drbd_find_path_by_addr()"
+
+This reverts commit 624e5e1585fc44a29a1ad00144551a8e02501259.
+
+This approach causes problems when a connection is lost and then quickly
+re-established. The first TCP connection is still in TIME_WAIT or a
+similar state, preventing the connect of the new connection. As a
+result, this feature brings no real benefit. Remove it.
+
+Signed-off-by: Joel Colledge <joel.colledge@linbit.com>
+---
+ drbd/drbd_transport.c | 17 ++++-------------
+ 1 file changed, 4 insertions(+), 13 deletions(-)
+
+diff --git a/drbd/drbd_transport.c b/drbd/drbd_transport.c
+index f37ccd37b..7c6128cbb 100644
+--- a/drbd/drbd_transport.c
++++ b/drbd/drbd_transport.c
+@@ -266,23 +266,14 @@ void drbd_put_listener(struct drbd_path *path)
+ 
+ struct drbd_path *drbd_find_path_by_addr(struct drbd_listener *listener, struct sockaddr_storage *addr)
+ {
+-	struct drbd_path *path, *ip_match = NULL;
+-
+-	/*
+-	 * Prefer an exact (IP, port) match. This disambiguates multiple paths
+-	 * that share a peer IP but have distinct peer_addr ports, as long as
+-	 * the peer (typically a DRBD proxy instance) binds its source port
+-	 * accordingly. Direct DRBD-to-DRBD peers use an ephemeral source port
+-	 * and are resolved by the first IP-only match.
+-	 */
++	struct drbd_path *path;
++
+ 	list_for_each_entry(path, &listener->waiters, listener_link) {
+-		if (addr_and_port_equal(&path->peer_addr, addr))
++		if (addr_equal(&path->peer_addr, addr))
+ 			return path;
+-		if (!ip_match && addr_equal(&path->peer_addr, addr))
+-			ip_match = path;
+ 	}
+ 
+-	return ip_match;
++	return NULL;
+ }
+ 
+ /**

--- a/SOURCES/0014-drbd-pin-listener-across-dtt_wait_for_connect-to-fix.patch
+++ b/SOURCES/0014-drbd-pin-listener-across-dtt_wait_for_connect-to-fix.patch
@@ -1,0 +1,203 @@
+From aad3ba1b37aa3a2463ca446b2f4b51f3eeee2017 Mon Sep 17 00:00:00 2001
+From: Philipp Reisner <philipp.reisner@linbit.com>
+Date: Tue, 19 May 2026 16:01:10 +0200
+Subject: [PATCH] drbd: pin listener across dtt_wait_for_connect() to fix
+ use-after-free
+
+dtt_wait_for_connect() slept on listener->wait, where listener is the
+struct dtt_listener pinned only by path->listener. While sleeping in
+wait_event_interruptible_timeout(), a concurrent del-path ->
+dtt_remove_path() -> drbd_put_listener() may drop the last reference on
+the listener and free it. The on-stack wait_queue_entry is then dangling
+on a freed wait_queue_head_t, and finish_wait() crashes:
+
+  kernel BUG at lib/list_debug.c:51!
+  RIP: 0010:__list_del_entry_valid.cold+0x31/0x47
+  Call Trace:
+   finish_wait+0x42/0x90
+   dtt_wait_for_connect.constprop.0+0x407/0x580 [drbd_transport_tcp]
+   dtt_connect+0x28e/0xdc3 [drbd_transport_tcp]
+   conn_connect+0xc6/0x760 [drbd]
+   drbd_receiver+0x14/0x60 [drbd]
+
+Fix this by getting an explicit reference on the listener in
+dtt_wait_for_connect().
+
+Fixes: dfa4fa2f24f1 ("drbd_transport_tcp: Fix connect time")
+Co-developed-by: Lars Ellenberg <lars.ellenberg@linbit.com>
+Signed-off-by: Lars Ellenberg <lars.ellenberg@linbit.com>
+Co-developed-by: Joel Colledge <joel.colledge@linbit.com>
+Signed-off-by: Joel Colledge <joel.colledge@linbit.com>
+Signed-off-by: Philipp Reisner <philipp.reisner@linbit.com>
+---
+ drbd/drbd_int.h           |  3 +++
+ drbd/drbd_transport.c     | 22 +++++++++++++++++++++
+ drbd/drbd_transport_tcp.c | 41 ++++++++++++++++++++++++++++++---------
+ 3 files changed, 57 insertions(+), 9 deletions(-)
+
+diff --git a/drbd/drbd_int.h b/drbd/drbd_int.h
+index 868b30492..a204116a6 100644
+--- a/drbd/drbd_int.h
++++ b/drbd/drbd_int.h
+@@ -2144,6 +2144,9 @@ void drbd_transport_shutdown(struct drbd_connection *connection,
+ void drbd_destroy_connection(struct kref *kref);
+ void conn_free_crypto(struct drbd_connection *connection);
+ 
++/* From drbd_transport.c; here because drbd-headers is frozen for drbd-9.2 */
++struct drbd_listener *drbd_listener_try_get_ref(struct drbd_path *path);
++
+ /* drbd_req */
+ void drbd_do_submit_conflict(struct work_struct *ws);
+ void do_submit(struct work_struct *ws);
+diff --git a/drbd/drbd_transport.c b/drbd/drbd_transport.c
+index 7c6128cbb..d7a06a516 100644
+--- a/drbd/drbd_transport.c
++++ b/drbd/drbd_transport.c
+@@ -264,6 +264,27 @@ void drbd_put_listener(struct drbd_path *path)
+ 	kref_put(&listener->kref, drbd_listener_destroy);
+ }
+ 
++/**
++ * drbd_listener_try_get_ref() - Acquire a reference to path->listener.
++ * @path: The path whose listener should be pinned.
++ *
++ * Necessary to protect from a concurrently running del-path.
++ */
++struct drbd_listener *drbd_listener_try_get_ref(struct drbd_path *path)
++{
++	struct drbd_connection *connection =
++		container_of(path->transport, struct drbd_connection, transport);
++	struct drbd_resource *resource = connection->resource;
++	struct drbd_listener *listener;
++
++	spin_lock_bh(&resource->listeners_lock);
++	listener = READ_ONCE(path->listener);
++	if (!listener || !kref_get_unless_zero(&listener->kref))
++		listener = NULL;
++	spin_unlock_bh(&resource->listeners_lock);
++	return listener;
++}
++
+ struct drbd_path *drbd_find_path_by_addr(struct drbd_listener *listener, struct sockaddr_storage *addr)
+ {
+ 	struct drbd_path *path;
+@@ -371,6 +392,7 @@ EXPORT_SYMBOL_GPL(drbd_register_transport_class);
+ EXPORT_SYMBOL_GPL(drbd_unregister_transport_class);
+ EXPORT_SYMBOL_GPL(drbd_get_listener);
+ EXPORT_SYMBOL_GPL(drbd_put_listener);
++EXPORT_SYMBOL_GPL(drbd_listener_try_get_ref);
+ EXPORT_SYMBOL_GPL(drbd_find_path_by_addr);
+ EXPORT_SYMBOL_GPL(drbd_stream_send_timed_out);
+ EXPORT_SYMBOL_GPL(drbd_should_abort_listening);
+diff --git a/drbd/drbd_transport_tcp.c b/drbd/drbd_transport_tcp.c
+index 8af6fdda2..2327f8d5c 100644
+--- a/drbd/drbd_transport_tcp.c
++++ b/drbd/drbd_transport_tcp.c
+@@ -105,6 +105,9 @@ struct dtt_path {
+ 	struct list_head sockets; /* sockets passed to me by other receiver threads */
+ };
+ 
++/* From drbd_transport.c; here because drbd-headers is frozen for drbd-9.2 */
++struct drbd_listener *drbd_listener_try_get_ref(struct drbd_path *path);
++
+ static int dtt_init(struct drbd_transport *transport);
+ static void dtt_free(struct drbd_transport *transport, enum drbd_tr_free_op free_op);
+ static void dtt_socket_free(struct socket **sock);
+@@ -689,7 +692,11 @@ static struct dtt_path *dtt_wait_connect_cond(struct drbd_transport *transport)
+ 	rcu_read_lock();
+ 	list_for_each_entry_rcu(drbd_path, &transport->paths, list) {
+ 		path = container_of(drbd_path, struct dtt_path, path);
+-		listener = drbd_path->listener;
++
++		/* Pairs with xchg() in drbd_put_listener() */
++		listener = READ_ONCE(drbd_path->listener);
++		if (!listener)
++			continue;
+ 
+ 		spin_lock_bh(&listener->waiters_lock);
+ 		rv = listener->pending_accepts > 0 || !list_empty(&path->sockets);
+@@ -714,7 +721,7 @@ static void unregister_state_change(struct sock *sock, struct dtt_listener *list
+ }
+ 
+ static int dtt_wait_for_connect(struct drbd_transport *transport,
+-				struct drbd_listener *drbd_listener, struct socket **socket,
++				struct socket **socket,
+ 				struct dtt_path **ret_path)
+ {
+ 	struct dtt_socket_container *socket_c;
+@@ -724,14 +731,23 @@ static int dtt_wait_for_connect(struct drbd_transport *transport,
+ 	struct socket *s_estab = NULL;
+ 	struct net_conf *nc;
+ 	struct drbd_path *drbd_path2;
+-	struct dtt_listener *listener = container_of(drbd_listener, struct dtt_listener, listener);
++	struct drbd_listener *drbd_listener;
++	struct dtt_listener *listener;
+ 	struct dtt_path *path = NULL;
+ 
++	/* Protect the listener from a concurrent del-path (drbd_put_listener()) */
++	drbd_listener = drbd_listener_try_get_ref(&(*ret_path)->path);
++	if (!drbd_listener)
++		return -EAGAIN;
++
++	listener = container_of(drbd_listener, struct dtt_listener, listener);
++
+ 	rcu_read_lock();
+ 	nc = rcu_dereference(transport->net_conf);
+ 	if (!nc) {
+ 		rcu_read_unlock();
+-		return -EINVAL;
++		err = -EINVAL;
++		goto out;
+ 	}
+ 	connect_int = nc->connect_int;
+ 	rcu_read_unlock();
+@@ -745,8 +761,10 @@ retry:
+ 	timeo = wait_event_interruptible_timeout(listener->wait,
+ 			(path = dtt_wait_connect_cond(transport)),
+ 			timeo);
+-	if (timeo <= 0)
+-		return -EAGAIN;
++	if (timeo <= 0) {
++		err = -EAGAIN;
++		goto out;
++	}
+ 
+ 	spin_lock_bh(&listener->listener.waiters_lock);
+ 	socket_c = list_first_entry_or_null(&path->sockets, struct dtt_socket_container, list);
+@@ -762,7 +780,7 @@ retry:
+ 		err = kernel_accept(listener->s_listen, &s_estab, O_NONBLOCK);
+ 		if (err < 0) {
+ 			kref_put(&path->path.kref, drbd_destroy_path);
+-			return err;
++			goto out;
+ 		}
+ 
+ 		/* The established socket inherits the sk_state_change callback
+@@ -817,12 +835,17 @@ retry:
+ 	if (*ret_path)
+ 		kref_put(&(*ret_path)->path.kref, drbd_destroy_path);
+ 	*ret_path = path;
+-	return 0;
++	err = 0;
++	goto out;
+ 
+ retry_locked:
+ 	spin_unlock_bh(&listener->listener.waiters_lock);
+ 	dtt_socket_free(&s_estab);
+ 	goto retry;
++
++out:
++	kref_put(&drbd_listener->kref, drbd_listener_destroy);
++	return err;
+ }
+ 
+ static int dtt_receive_first_packet(struct drbd_tcp_transport *tcp_transport, struct socket *socket)
+@@ -1223,7 +1246,7 @@ static int dtt_connect(struct drbd_transport *transport)
+ 
+ retry:
+ 		s = NULL;
+-		err = dtt_wait_for_connect(transport, connect_to_path->path.listener, &s, &connect_to_path);
++		err = dtt_wait_for_connect(transport, &s, &connect_to_path);
+ 		if (err < 0 && err != -EAGAIN)
+ 			goto out_release_sockets;
+ 

--- a/SOURCES/0015-drbd-move-TCP-listener-wait-queue-to-tcp_transport.patch
+++ b/SOURCES/0015-drbd-move-TCP-listener-wait-queue-to-tcp_transport.patch
@@ -1,0 +1,120 @@
+From 36b894b77d238493a52e9c0dcc3b5ae2f30c604b Mon Sep 17 00:00:00 2001
+From: Philipp Reisner <philipp.reisner@linbit.com>
+Date: Tue, 19 May 2026 16:02:25 +0200
+Subject: [PATCH] drbd: move TCP listener wait queue to tcp_transport
+
+TCP was the odd one out among the three transports: lb-tcp and rdma both
+place their connect-side wait primitive in the per-transport struct
+(dtl_transport->connected_paths_change, dtr_transport->connected) and
+fan out from the listener via a work_struct or rdma_cm callback. Only
+TCP's listener owned a wait_queue_head_t that the receiver slept on
+directly.
+
+Move wait from struct dtt_listener to struct drbd_tcp_transport, which
+has connection lifetime. This aligns the three transports and removes
+the thundering-herd wake-up on a shared listener: previously every
+receiver on every path under the listener woke and re-ran
+dtt_wait_connect_cond(); with the per-transport waitqueue the producer
+can wake only the target path's transport.
+
+Signed-off-by: Philipp Reisner <philipp.reisner@linbit.com>
+---
+ drbd/drbd_transport_tcp.c | 22 ++++++++++++++++------
+ 1 file changed, 16 insertions(+), 6 deletions(-)
+
+diff --git a/drbd/drbd_transport_tcp.c b/drbd/drbd_transport_tcp.c
+index 2327f8d5c..38b843461 100644
+--- a/drbd/drbd_transport_tcp.c
++++ b/drbd/drbd_transport_tcp.c
+@@ -80,14 +80,13 @@ struct drbd_tcp_transport {
+ 	struct work_struct control_data_ready_work;
+ 	void (*original_control_sk_state_change)(struct sock *sk);
+ 	void (*original_control_sk_data_ready)(struct sock *sk);
++	wait_queue_head_t wait; /* woken if a connection came in on any of our paths */
+ };
+ 
+ struct dtt_listener {
+ 	struct drbd_listener listener;
+ 	void (*original_sk_state_change)(struct sock *sk);
+ 	struct socket *s_listen;
+-
+-	wait_queue_head_t wait; /* woken if a connection came in */
+ };
+ 
+ /* Since each path might have a different local IP address, each
+@@ -174,6 +173,7 @@ static int dtt_init(struct drbd_transport *transport)
+ 	enum drbd_stream i;
+ 
+ 	spin_lock_init(&tcp_transport->control_recv_lock);
++	init_waitqueue_head(&tcp_transport->wait);
+ 	tcp_transport->transport.class = &tcp_transport_class;
+ 	for (i = DATA_STREAM; i <= CONTROL_STREAM ; i++) {
+ 		void *buffer = (void *)__get_free_page(GFP_KERNEL);
+@@ -724,6 +724,8 @@ static int dtt_wait_for_connect(struct drbd_transport *transport,
+ 				struct socket **socket,
+ 				struct dtt_path **ret_path)
+ {
++	struct drbd_tcp_transport *tcp_transport =
++		container_of(transport, struct drbd_tcp_transport, transport);
+ 	struct dtt_socket_container *socket_c;
+ 	struct sockaddr_storage peer_addr;
+ 	int connect_int, err = 0;
+@@ -758,7 +760,7 @@ static int dtt_wait_for_connect(struct drbd_transport *transport,
+ retry:
+ 	if (path)
+ 		kref_put(&path->path.kref, drbd_destroy_path);
+-	timeo = wait_event_interruptible_timeout(listener->wait,
++	timeo = wait_event_interruptible_timeout(tcp_transport->wait,
+ 			(path = dtt_wait_connect_cond(transport)),
+ 			timeo);
+ 	if (timeo <= 0) {
+@@ -813,6 +815,9 @@ retry:
+ 		if (drbd_path2 != &path->path) {
+ 			struct dtt_path *path2 =
+ 				container_of(drbd_path2, struct dtt_path, path);
++			struct drbd_tcp_transport *path2_tcp_transport =
++				container_of(drbd_path2->transport,
++					     struct drbd_tcp_transport, transport);
+ 
+ 			socket_c = kmalloc_obj(*socket_c, GFP_ATOMIC);
+ 			if (!socket_c) {
+@@ -824,7 +829,7 @@ retry:
+ 			socket_c->socket = s_estab;
+ 			s_estab = NULL;
+ 			list_add_tail(&socket_c->list, &path2->sockets);
+-			wake_up(&listener->wait);
++			wake_up(&path2_tcp_transport->wait);
+ 			goto retry_locked;
+ 		}
+ 		if (s_estab->sk->sk_state != TCP_ESTABLISHED)
+@@ -986,6 +991,7 @@ static void dtt_control_state_change(struct sock *sock)
+ static void dtt_incoming_connection(struct sock *sock)
+ {
+ 	struct dtt_listener *listener = sock->sk_user_data;
++	struct drbd_path *drbd_path;
+ 	void (*state_change)(struct sock *sock);
+ 
+ 	state_change = listener->original_sk_state_change;
+@@ -993,8 +999,13 @@ static void dtt_incoming_connection(struct sock *sock)
+ 
+ 	spin_lock(&listener->listener.waiters_lock);
+ 	listener->listener.pending_accepts++;
++	list_for_each_entry(drbd_path, &listener->listener.waiters, listener_link) {
++		struct drbd_tcp_transport *tcp_transport =
++			container_of(drbd_path->transport,
++				     struct drbd_tcp_transport, transport);
++		wake_up(&tcp_transport->wait);
++	}
+ 	spin_unlock(&listener->listener.waiters_lock);
+-	wake_up(&listener->wait);
+ }
+ 
+ static void dtt_control_timer_fn(struct timer_list *t)
+@@ -1074,7 +1085,6 @@ static int dtt_init_listener(struct drbd_transport *transport,
+ 	}
+ 
+ 	listener->listener.listen_addr = my_addr;
+-	init_waitqueue_head(&listener->wait);
+ 
+ 	return 0;
+ out:

--- a/SOURCES/0016-drbd-initialize-drbd_resources-list-head-statically.patch
+++ b/SOURCES/0016-drbd-initialize-drbd_resources-list-head-statically.patch
@@ -1,0 +1,42 @@
+From 410407a20f76627f68aff308d957d1cea9457154 Mon Sep 17 00:00:00 2001
+From: Philipp Reisner <philipp.reisner@linbit.com>
+Date: Thu, 21 May 2026 11:44:34 +0200
+Subject: [PATCH] drbd: initialize drbd_resources list head statically
+
+When the max_parallel_resyncs module parameter is set at load time,
+the kernel processes module parameters in parse_args() before invoking
+the module init function.
+The custom setter param_set_max_parallel_resyncs() calls
+drbd_apply_resync_max_parallel(), At that point the list
+head is still zeroed BSS, so for_each_resource() dereferences a NULL
+next pointer and oopses.
+
+Fix this by declaring drbd_resources with LIST_HEAD().
+
+Signed-off-by: Philipp Reisner <philipp.reisner@linbit.com>
+---
+ drbd/drbd_main.c | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/drbd/drbd_main.c b/drbd/drbd_main.c
+index 863ea464e..76fcd5350 100644
+--- a/drbd/drbd_main.c
++++ b/drbd/drbd_main.c
+@@ -170,7 +170,7 @@ module_param_named(strict_names, drbd_strict_names, drbd_strict_names, 0644);
+  * as member "struct gendisk *vdisk;"
+  */
+ struct idr drbd_devices;
+-struct list_head drbd_resources;
++LIST_HEAD(drbd_resources);
+ static DEFINE_SPINLOCK(drbd_devices_lock);
+ DEFINE_MUTEX(resources_mutex);
+ 
+@@ -4492,8 +4492,6 @@ static int __init drbd_init(void)
+ 	drbd_proc = NULL; /* play safe for drbd_cleanup */
+ 	idr_init(&drbd_devices);
+ 
+-	INIT_LIST_HEAD(&drbd_resources);
+-
+ 	err = register_pernet_device(&drbd_pernet_ops);
+ 	if (err) {
+ 		pr_err("unable to register net namespace handlers\n");

--- a/SOURCES/0017-build-avoid-stdin-hang-when-kernel-.config-is-unavai.patch
+++ b/SOURCES/0017-build-avoid-stdin-hang-when-kernel-.config-is-unavai.patch
@@ -1,0 +1,65 @@
+From 947c7f1b7e8c9f0016cc01d8ae9de54e61360e27 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Christoph=20B=C3=B6hmwalder?=
+ <christoph.boehmwalder@linbit.com>
+Date: Thu, 21 May 2026 17:56:10 +0200
+Subject: [PATCH] build: avoid stdin hang when kernel .config is unavailable
+
+Commit d889246752 ("build: stamp compat.h against include/config/auto.conf,
+not .config") fixed the freshness check for kernels installed via stock
+bindeb-pkg, where $(objtree)/.config is no longer shipped since Linux
+v6.12 commit aaed5c7739be ("kbuild: slim down package for building external
+modules").
+
+The .kernel.config.gz recipe has the same assumption baked in: when neither
+$(objtree)/.config nor $(srctree)/.config exists, the kconfig variable
+expands to the empty string, config= stays empty, and "cat $config" reads
+from stdin and hangs the build forever.
+
+Add include/config/auto.conf as a third fallback in the wildcard. It is
+regenerated from .config on every kconfig change and is shipped by every
+modern kernel-headers package, so it is always present when the .config
+file is not. The CONFIG_*=... assignments it contains are sufficient for
+the documentation purpose of this artifact (it is shipped as %doc
+k-config-<kernelrelease>.gz and not consumed by anything functional).
+
+Also guard the cat with a non-empty check so that even if all three
+candidates are absent the recipe emits a marker line instead of blocking
+on stdin.
+
+Signed-off-by: Christoph Boehmwalder <christoph.boehmwalder@linbit.com>
+---
+ drbd/Kbuild | 14 +++++++++-----
+ 1 file changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/drbd/Kbuild b/drbd/Kbuild
+index a26e084d6..6979d5c1e 100644
+--- a/drbd/Kbuild
++++ b/drbd/Kbuild
+@@ -286,7 +286,7 @@ endef
+ $(obj.build)/.drbd_kernelrelease: /dev/null FORCE
+ 	$(call filechk,.drbd_kernelrelease)
+ 
+-kconfig := $(realpath $(word 1,$(wildcard $(objtree)/.config $(srctree)/.config)))
++kconfig := $(realpath $(word 1,$(wildcard $(objtree)/.config $(srctree)/.config $(objtree)/include/config/auto.conf)))
+ $(obj.build)/.kernel.config.gz: $(obj.build)/.drbd_kernelrelease $(kconfig)
+ 	@$(kecho) '  GEN     $@ $(echo-why)'
+ 	$(Q)config=$(kconfig)                                   ; \
+@@ -294,10 +294,14 @@ $(obj.build)/.kernel.config.gz: $(obj.build)/.drbd_kernelrelease $(kconfig)
+ 	  echo "#  `$(CC) -v 2>&1 | tail -1`"               ; \
+ 	  echo "# against this kernelrelease:"              ; \
+ 	  sed 's/^/#  /' $<                                 ; \
+-	  echo    "# kernel .config from"                   ; \
+-	  echo    "#  $$config"                             ; \
+-	  echo -e "# follows\n#\n"                          ; \
+-	  cat $$config ; } | gzip > $@.new && mv $@.new $@
++	  if [ -n "$$config" ]; then                          \
++	    echo    "# kernel .config from"                 ; \
++	    echo    "#  $$config"                           ; \
++	    echo -e "# follows\n#\n"                        ; \
++	    cat $$config                                    ; \
++	  else                                                \
++	    echo -e "# kernel .config not available\n#\n"   ; \
++	  fi ; } | gzip > $@.new && mv $@.new $@
+ 
+ # for some reason some of the commands below only work correctly in bash,
+ # and not in e.g. dash. I'm too lazy to fix it to be compatible.

--- a/SOURCES/0018-drbd-cancel_dagtag_dependent_requests-remove-interva.patch
+++ b/SOURCES/0018-drbd-cancel_dagtag_dependent_requests-remove-interva.patch
@@ -1,0 +1,118 @@
+From 4599e374fbe54d5ec95581debc232e73027d4646 Mon Sep 17 00:00:00 2001
+From: Lars Ellenberg <lars.ellenberg@linbit.com>
+Date: Fri, 22 May 2026 21:41:48 +0200
+Subject: [PATCH] drbd: cancel_dagtag_dependent_requests: remove interval,
+ release refs, handle all matches
+
+cancel_dagtag_dependent_requests() walks every connection's
+dagtag_wait_ee on behalf of a disconnecting peer. Entries of type
+INTERVAL_OV_READ_SOURCE that landed on a wait list belonging to a
+different (still-up) connection are still linked in device->requests:
+they came in via receive_common_ov_reply() -> find_resync_request(),
+which by construction returns peer_reqs already present in the interval
+tree.
+
+Freeing such an entry without first calling drbd_remove_peer_req_interval()
+leaves a dangling rb_node in device->requests. The kernel emits
+
+  ASSERTION drbd_interval_empty(&peer_req->i) FAILED in drbd_free_peer_req
+
+at the time of the bad free, but D_ASSERT only prints, so the free
+proceeds and the corruption sticks. The next walker of that tree
+(typically drbd_cancel_conflicting_resync_requests() during another
+drain_resync_activity()) takes a general protection fault on a
+non-canonical address inside rb_next(), holding device->interval_lock.
+Other CPUs spin on it, the resource's state_rwlock wedges, and the
+system progresses through soft-lockups and RCU stalls to a freeze.
+
+Mirror the cleanup done by free_dagtag_wait_requests(): remove the
+interval from the tree for INTERVAL_OV_READ_SOURCE, then release the
+unacked counter and the ldev reference that were taken in
+receive_common_data_request() / receive_common_ov_reply() before the
+peer_req reached drbd_peer_resync_read().
+
+While here, fix two adjacent bugs in the same function:
+
+- The inner list iteration used list_for_each_entry() + break, so at
+  most one matching peer_req per connection was cancelled; the rest
+  stayed parked waiting for a dagtag that would never arrive (until
+  their own connection later dropped and free_dagtag_wait_requests()
+  caught them).
+
+  The break-after-list_move pattern is legitimate in the sibling
+  function find_released_peer_request(), because release_dagtag_wait()
+  reissues it in a while-loop and processes one peer_req at a time
+  outside the spinlock. cancel_dagtag_dependent_requests() has no
+  such outer loop -- it collects into work_list and processes the
+  work_list once in a separate pass after rcu_read_unlock -- so a
+  copy-paste of the break drops every match after the first. Switch
+  to list_for_each_entry_safe() and remove the break, so all matching
+  entries are collected in one go.
+
+  Multiple matching entries per connection is not hypothetical for
+  this code path: when an OV source on A is sending a stream of
+  P_OV_REQUESTs to B while C is writing, B's replies all carry
+  monotonically increasing depend_dagtags from C; several of those
+  replies may sit on the A-B connection's dagtag_wait_ee at the
+  moment A-C drops.
+
+- dec_unacked() and put_ldev() were not called, leaking an unacked
+  slot and the ldev reference taken in the receive paths.
+
+The interval-tree-removal regression dates to commit 0ef43542eff7
+("drbd: fix fault when cancelling resync read"), which moved
+drbd_remove_peer_req_interval() out of drbd_peer_resync_read_cancel()
+into callers and added it back to receive_common_ov_reply() but not
+to this one (first released in drbd-9.2.6). The other two issues go
+back to commit 223009b6369f ("drbd: synchronize resync with interval
+tree and dagtags") and have been present since drbd-9.2.0.
+
+dagtag-synchronized resync (and these helpers) does not exist on
+drbd-9.1 or drbd-9.0, so no backport beyond drbd-9.2 is needed.
+
+Fixes: 0ef43542eff7 ("drbd: fix fault when cancelling resync read")
+Signed-off-by: Lars Ellenberg <lars.ellenberg@linbit.com>
+---
+ drbd/drbd_receiver.c | 14 ++++++++++++--
+ 1 file changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/drbd/drbd_receiver.c b/drbd/drbd_receiver.c
+index 953411f1e..28f947249 100644
+--- a/drbd/drbd_receiver.c
++++ b/drbd/drbd_receiver.c
+@@ -9502,7 +9502,7 @@ static void cancel_dagtag_dependent_requests(struct drbd_resource *resource, uns
+ 	rcu_read_lock();
+ 	for_each_connection_rcu(connection, resource) {
+ 		spin_lock_irq(&connection->peer_reqs_lock);
+-		list_for_each_entry(peer_req, &connection->dagtag_wait_ee, w.list) {
++		list_for_each_entry_safe(peer_req, t, &connection->dagtag_wait_ee, w.list) {
+ 			if (peer_req->depend_dagtag_node_id != node_id)
+ 				continue;
+ 
+@@ -9513,15 +9513,25 @@ static void cancel_dagtag_dependent_requests(struct drbd_resource *resource, uns
+ 					node_id);
+ 
+ 			list_move_tail(&peer_req->w.list, &work_list);
+-			break;
+ 		}
+ 		spin_unlock_irq(&connection->peer_reqs_lock);
+ 	}
+ 	rcu_read_unlock();
+ 
+ 	list_for_each_entry_safe(peer_req, t, &work_list, w.list) {
++		struct drbd_peer_device *peer_device = peer_req->peer_device;
++
+ 		drbd_peer_resync_read_cancel(peer_req);
++		/* Verify requests on the source side are placed in the
++		 * interval tree when the request is made; they need to be
++		 * removed if the reply was parked waiting for a dagtag.
++		 * Mirrors free_dagtag_wait_requests().
++		 */
++		if (peer_req->i.type == INTERVAL_OV_READ_SOURCE)
++			drbd_remove_peer_req_interval(peer_req);
+ 		drbd_free_peer_req(peer_req);
++		dec_unacked(peer_device);
++		put_ldev(peer_device->device);
+ 	}
+ }
+ 

--- a/SOURCES/0019-drbd-drop-double-dec_rs_pending-in-drbd_peer_resync_.patch
+++ b/SOURCES/0019-drbd-drop-double-dec_rs_pending-in-drbd_peer_resync_.patch
@@ -1,0 +1,65 @@
+From d6e80251aed59f6a64d29c0266cd61f4eea8222b Mon Sep 17 00:00:00 2001
+From: Lars Ellenberg <lars.ellenberg@linbit.com>
+Date: Fri, 22 May 2026 21:42:09 +0200
+Subject: [PATCH] drbd: drop double dec_rs_pending in
+ drbd_peer_resync_read_cancel OV_READ_SOURCE path
+
+For an OV source, rs_pending is incremented exactly once in
+drbd_conflict_send_ov_request() when the P_OV_REQUEST is sent, and
+decremented exactly once in receive_common_ov_reply() at the top of
+the function, before either of the two paths that subsequently reach
+drbd_peer_resync_read_cancel():
+
+  1. the in-line get_ldev_if_state() failure cleanup in
+     receive_common_ov_reply(), which calls
+     drbd_peer_resync_read_cancel() immediately after the explicit dec;
+
+  2. cancel_dagtag_dependent_requests(), which acts on peer_reqs that
+     were parked on dagtag_wait_ee by drbd_peer_resync_read() after
+     receive_common_ov_reply() had already done the dec.
+
+The extra dec_rs_pending() in the INTERVAL_OV_READ_SOURCE branch of
+drbd_peer_resync_read_cancel() therefore drives the counter below zero,
+which the kernel reports as:
+
+  ASSERTION __dec_rs_pending(peer_device) >= 0 FAILED in
+    drbd_peer_resync_read_cancel
+  ASSERTION __dec_rs_pending(peer_device) >= 0 FAILED in
+    receive_common_ov_reply  (repeating)
+  ASSERTION atomic_read(&peer_device->rs_pending_cnt) == 0 FAILED in
+    cleanup_resync_leftovers
+
+The first line is the original double-dec; the next ones are subsequent
+P_OV_REPLY arrivals each dec'ing from an already-negative counter; the
+last one is the disconnect drain seeing rs_pending_cnt != 0 at shutdown.
+
+Both callers already decrement, so the cancel helper must not. Remove it.
+
+Present since commit 223009b6369f ("drbd: synchronize resync with interval
+tree and dagtags") (drbd-9.2.0). dagtag-synchronized resync does not
+exist on drbd-9.1 or drbd-9.0, so no backport beyond drbd-9.2 is needed.
+
+Signed-off-by: Lars Ellenberg <lars.ellenberg@linbit.com>
+---
+ drbd/drbd_receiver.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/drbd/drbd_receiver.c b/drbd/drbd_receiver.c
+index 28f947249..f26fda29f 100644
+--- a/drbd/drbd_receiver.c
++++ b/drbd/drbd_receiver.c
+@@ -3646,8 +3646,12 @@ static void drbd_peer_resync_read_cancel(struct drbd_peer_request *peer_req)
+ 	u64 block_id = peer_req->block_id;
+ 
+ 	if (peer_req->i.type == INTERVAL_OV_READ_SOURCE) {
+-		/* P_OV_REPLY */
+-		dec_rs_pending(peer_device);
++		/* P_OV_REPLY.
++		 * rs_pending was already decremented in
++		 * receive_common_ov_reply() before the peer_req reached
++		 * either of the two paths that call us; do not decrement
++		 * again.
++		 */
+ 		drbd_send_ov_result(peer_device, sector, size, block_id, OV_RESULT_SKIP);
+ 	} else if (peer_req->i.type == INTERVAL_OV_READ_TARGET) {
+ 		/* P_OV_REQUEST */

--- a/SOURCES/0020-drbd-fix-list-corruption-when-freeing-peer_req-from-.patch
+++ b/SOURCES/0020-drbd-fix-list-corruption-when-freeing-peer_req-from-.patch
@@ -1,0 +1,59 @@
+From 7ede778810ce872ab1ac3f866a8a524a73c45d77 Mon Sep 17 00:00:00 2001
+From: Philipp Reisner <philipp.reisner@linbit.com>
+Date: Thu, 28 May 2026 19:38:40 +0200
+Subject: [PATCH] drbd: fix list corruption when freeing peer_req from send_oos
+ list, part 2
+
+cleanup_unacked_peer_requests() splices connection->peer_requests onto
+a work_list and then onto peer_ack_connection->send_oos via
+drbd_queue_send_out_of_sync(), just like got_peer_ack() does. The fix
+for got_peer_ack() (clearing EE_ON_RECV_ORDER and setting EE_ON_SEND_OOS
+on peer_requests that move to send_oos) was not applied to this second
+producer.
+
+As a result, when a connection drops with peer_requests still pending,
+those peer_requests land on send_oos with EE_ON_RECV_ORDER still set.
+drbd_send_oos_from() then list_del's the entry under send_oos_lock and
+calls drbd_free_peer_req(), which sees EE_ON_RECV_ORDER, takes
+peer_reqs_lock, and list_del's the already-poisoned entry a second
+time:
+
+  drbd ... Connection closed
+  list_del corruption, ...->next is LIST_POISON1 (dead000000000100)
+  kernel BUG at lib/list_debug.c:56!
+   __list_del_entry_valid_or_report.cold+0x5c/0x6f
+   drbd_free_peer_req+0xda/0x1b0 [drbd]
+   drbd_send_oos_from+0x20c/0x260 [drbd]
+   drbd_send_out_of_sync_wf+0x50/0x80 [drbd]
+   drbd_sender+0x166/0x500 [drbd]
+
+Fix this by applying the same flag dance as got_peer_ack(): when the
+peer_req has send_oos_pending and will be moved to send_oos, clear
+EE_ON_RECV_ORDER and set EE_ON_SEND_OOS so drbd_free_peer_req() does
+not later try to list_del it under peer_reqs_lock.
+
+Fixes: 198d4ebdaa12 ("drbd: distinguish send_oos list membership with EE_ON_SEND_OOS")
+Signed-off-by: Philipp Reisner <philipp.reisner@linbit.com>
+---
+ drbd/drbd_receiver.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/drbd/drbd_receiver.c b/drbd/drbd_receiver.c
+index f26fda29f..7d1cc155b 100644
+--- a/drbd/drbd_receiver.c
++++ b/drbd/drbd_receiver.c
+@@ -11223,8 +11223,12 @@ static void cleanup_unacked_peer_requests(struct drbd_connection *connection)
+ 
+ 		peer_req->send_oos_pending = drbd_calculate_send_oos_pending(device, 0);
+ 		any_send_oos_pending |= peer_req->send_oos_pending;
+-		if (!peer_req->send_oos_pending)
+-			drbd_free_peer_req(peer_req);
++		if (peer_req->send_oos_pending) {
++			peer_req->flags &= ~EE_ON_RECV_ORDER;
++			peer_req->flags |= EE_ON_SEND_OOS;
++		} else {
++			drbd_free_peer_req(peer_req); /* list_del() because EE_ON_RECV_ORDER */
++		}
+ 	}
+ 
+ 	drbd_queue_send_out_of_sync(connection, &work_list, any_send_oos_pending);

--- a/SOURCES/0021-Revert-drbd-rework-autopromote.patch
+++ b/SOURCES/0021-Revert-drbd-rework-autopromote.patch
@@ -1,4 +1,4 @@
-From adf72cc18024caa60cd2cac764701de5e2eb2b74 Mon Sep 17 00:00:00 2001
+From 0e3db9277ba86c3790cd24aca1da600099dd0a66 Mon Sep 17 00:00:00 2001
 From: Philipp Reisner <philipp.reisner@linbit.com>
 Date: Fri, 5 Jul 2024 12:00:09 +0200
 Subject: [PATCH] Revert "drbd: rework autopromote"
@@ -46,12 +46,12 @@ index b0a0ee9ee..4c57be0b8 100644
  symbol drbd_release;
  expression gd;
 diff --git a/drbd/drbd_int.h b/drbd/drbd_int.h
-index abeede189..ebe1b38e5 100644
+index a204116a6..20bf0a259 100644
 --- a/drbd/drbd_int.h
 +++ b/drbd/drbd_int.h
-@@ -1581,8 +1581,7 @@ struct drbd_device {
+@@ -1586,8 +1586,7 @@ struct drbd_device {
  
- 	struct drbd_bitmap *bitmap;
+ 	struct drbd_bitmap *bitmap; /* enclose accessing code in get_ldev() / put_ldev() */
  
 -	int open_cnt;
 -	bool writable;
@@ -60,10 +60,10 @@ index abeede189..ebe1b38e5 100644
  	 * members are protected by what */
  
 diff --git a/drbd/drbd_main.c b/drbd/drbd_main.c
-index dd1fb2fe4..2a1e23c15 100644
+index 76fcd5350..05503356c 100644
 --- a/drbd/drbd_main.c
 +++ b/drbd/drbd_main.c
-@@ -2724,16 +2724,17 @@ static enum ioc_rv inc_open_count(struct drbd_device *device, blk_mode_t mode)
+@@ -2746,16 +2746,17 @@ static enum ioc_rv inc_open_count(struct drbd_device *device, blk_mode_t mode)
  		r = IOC_ABORT;
  	else if (resource->remote_state_change &&
  		resource->role[NOW] != R_PRIMARY &&
@@ -85,7 +85,7 @@ index dd1fb2fe4..2a1e23c15 100644
  	}
  	read_unlock_irq(&resource->state_rwlock);
  
-@@ -2813,7 +2814,6 @@ static int drbd_open(struct gendisk *gd, blk_mode_t mode)
+@@ -2835,7 +2836,6 @@ static int drbd_open(struct gendisk *gd, blk_mode_t mode)
  	struct drbd_resource *resource = device->resource;
  	long timeout = resource->res_opts.auto_promote_timeout * HZ / 10;
  	enum drbd_state_rv rv = SS_UNKNOWN_ERROR;
@@ -93,7 +93,7 @@ index dd1fb2fe4..2a1e23c15 100644
  	enum ioc_rv r;
  	int err = 0;
  
-@@ -2837,7 +2837,6 @@ static int drbd_open(struct gendisk *gd, blk_mode_t mode)
+@@ -2859,7 +2859,6 @@ static int drbd_open(struct gendisk *gd, blk_mode_t mode)
  	kref_debug_get(&device->kref_debug, 3);
  
  	mutex_lock(&resource->open_release);
@@ -101,7 +101,7 @@ index dd1fb2fe4..2a1e23c15 100644
  
  	timeout = wait_event_interruptible_timeout(resource->twopc_wait,
  						   (r = inc_open_count(device, mode)),
-@@ -2901,7 +2900,7 @@ out:
+@@ -2923,7 +2922,7 @@ out:
  	if (!err) {
  		add_opener(device, rv >= SS_SUCCESS);
  		/* Only interested in first open and last close. */
@@ -110,7 +110,7 @@ index dd1fb2fe4..2a1e23c15 100644
  			struct device_info info;
  
  			device_to_info(&info, device);
-@@ -2909,8 +2908,7 @@ out:
+@@ -2931,8 +2930,7 @@ out:
  			notify_device_state(NULL, 0, device, &info, NOTIFY_CHANGE);
  			mutex_unlock(&notification_mutex);
  		}
@@ -120,7 +120,7 @@ index dd1fb2fe4..2a1e23c15 100644
  
  	mutex_unlock(&resource->open_release);
  	if (err) {
-@@ -2929,10 +2927,8 @@ void drbd_open_counts(struct drbd_resource *resource, int *rw_count_ptr, int *ro
+@@ -2951,10 +2949,8 @@ void drbd_open_counts(struct drbd_resource *resource, int *rw_count_ptr, int *ro
  
  	rcu_read_lock();
  	idr_for_each_entry(&resource->devices, device, vnr) {
@@ -133,7 +133,7 @@ index dd1fb2fe4..2a1e23c15 100644
  	}
  	rcu_read_unlock();
  	*rw_count_ptr = rw_count;
-@@ -3002,9 +2998,14 @@ static void drbd_release(struct gendisk *gd)
+@@ -3024,9 +3020,14 @@ static void drbd_release(struct gendisk *gd)
  	struct drbd_resource *resource = device->resource;
  	int open_rw_cnt, open_ro_cnt;
  
@@ -148,7 +148,7 @@ index dd1fb2fe4..2a1e23c15 100644
  	 * We still want our side effects of drbd_fsync_device():
  	 * wait until all peers confirmed they have all the data, regardless of
  	 * replication protocol, even if that is asynchronous.
-@@ -3012,17 +3013,21 @@ static void drbd_release(struct gendisk *gd)
+@@ -3034,17 +3035,21 @@ static void drbd_release(struct gendisk *gd)
  	 * won't confuse drbd_reject_write_early() or other code paths that may
  	 * check for open_cnt != 0 when they see write requests.
  	 */
@@ -175,7 +175,7 @@ index dd1fb2fe4..2a1e23c15 100644
  	    !test_and_set_bit(DESTROYING_DEV, &device->flags))
  		call_rcu(&device->rcu, drbd_reclaim_device);
  
-@@ -3063,11 +3068,12 @@ static void drbd_release(struct gendisk *gd)
+@@ -3085,11 +3090,12 @@ static void drbd_release(struct gendisk *gd)
  		end_state_change(resource, &irq_flags, "release");
  	}
  
@@ -192,10 +192,10 @@ index dd1fb2fe4..2a1e23c15 100644
  
  		device_to_info(&info, device);
 diff --git a/drbd/drbd_nl.c b/drbd/drbd_nl.c
-index 6264e809b..811c0a817 100644
+index b932c0620..02cfe020d 100644
 --- a/drbd/drbd_nl.c
 +++ b/drbd/drbd_nl.c
-@@ -1272,9 +1272,10 @@ void youngest_and_oldest_opener_to_str(struct drbd_device *device, char *buf, si
+@@ -1278,9 +1278,10 @@ void youngest_and_oldest_opener_to_str(struct drbd_device *device, char *buf, si
  
  	buf[0] = '\0';
  	/* Do we have opener information? */
@@ -208,7 +208,7 @@ index 6264e809b..811c0a817 100644
  	if (cnt > 0 && cnt < len) {
  		buf += cnt;
  		len -= cnt;
-@@ -1297,7 +1298,7 @@ void youngest_and_oldest_opener_to_str(struct drbd_device *device, char *buf, si
+@@ -1303,7 +1304,7 @@ void youngest_and_oldest_opener_to_str(struct drbd_device *device, char *buf, si
  			ts = ktime_to_timespec64(last->opened);
  			time64_to_tm(ts.tv_sec, -sys_tz.tz_minuteswest * 60, &tm);
  			snprintf(buf, len, "%s%s:%d:%04ld-%02d-%02d_%02d:%02d:%02d.%03ld]",
@@ -217,7 +217,7 @@ index 6264e809b..811c0a817 100644
  			      last->comm, last->pid,
  			      tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
  			      tm.tm_hour, tm.tm_min, tm.tm_sec, ts.tv_nsec / NSEC_PER_MSEC);
-@@ -1315,13 +1316,13 @@ static int put_device_opener_info(struct drbd_device *device, struct sk_buff *re
+@@ -1321,13 +1322,13 @@ static int put_device_opener_info(struct drbd_device *device, struct sk_buff *re
  	char *dotdotdot = "";
  
  	spin_lock(&device->openers_lock);
@@ -234,7 +234,7 @@ index 6264e809b..811c0a817 100644
  	list_for_each_entry(o, &device->openers, list) {
  		ts = ktime_to_timespec64(o->opened);
  		time64_to_tm(ts.tv_sec, -sys_tz.tz_minuteswest * 60, &tm);
-@@ -4254,7 +4255,7 @@ static void __device_to_info(struct device_info *info,
+@@ -4411,7 +4412,7 @@ static void __device_to_info(struct device_info *info,
  			     struct drbd_device *device)
  {
  	info->is_intentional_diskless = device->device_conf.intentional_diskless;
@@ -242,8 +242,8 @@ index 6264e809b..811c0a817 100644
 +	info->dev_is_open = device->open_ro_cnt + device->open_rw_cnt != 0;
  
  	rcu_read_lock();
- 	if (get_ldev(device)) {
-@@ -4911,10 +4912,8 @@ int drbd_open_ro_count(struct drbd_resource *resource)
+ 	if (get_ldev_if_state(device, D_FAILED)) {
+@@ -5068,10 +5069,8 @@ int drbd_open_ro_count(struct drbd_resource *resource)
  	int vnr, open_ro_cnt = 0;
  
  	read_lock_irq(&resource->state_rwlock);
@@ -256,7 +256,7 @@ index 6264e809b..811c0a817 100644
  	read_unlock_irq(&resource->state_rwlock);
  
  	return open_ro_cnt;
-@@ -7091,7 +7090,8 @@ static enum drbd_ret_code adm_del_minor(struct drbd_device *device)
+@@ -7253,7 +7252,8 @@ static enum drbd_ret_code adm_del_minor(struct drbd_device *device)
  	notify_device_state(NULL, 0, device, NULL, NOTIFY_DESTROY);
  	mutex_unlock(&notification_mutex);
  
@@ -267,10 +267,10 @@ index 6264e809b..811c0a817 100644
  
  	return ret;
 diff --git a/drbd/drbd_req.c b/drbd/drbd_req.c
-index 856adf7d2..feff59d65 100644
+index 892640026..b03c22713 100644
 --- a/drbd/drbd_req.c
 +++ b/drbd/drbd_req.c
-@@ -2568,9 +2568,9 @@ static bool drbd_reject_write_early(struct drbd_device *device, struct bio *bio)
+@@ -2578,9 +2578,9 @@ static bool drbd_reject_write_early(struct drbd_device *device, struct bio *bio)
  			kfree(buf);
  		}
  		return true;
@@ -282,7 +282,7 @@ index 856adf7d2..feff59d65 100644
  		/*
  		 * If the resource was (temporarily, auto) promoted,
  		 * a remount,rw may have succeeded without marking the device
-@@ -2580,9 +2580,10 @@ static bool drbd_reject_write_early(struct drbd_device *device, struct bio *bio)
+@@ -2590,9 +2590,10 @@ static bool drbd_reject_write_early(struct drbd_device *device, struct bio *bio)
  		 * mutex to protect against races with new openers.
  		 */
  		mutex_lock(&resource->open_release);
@@ -297,10 +297,10 @@ index 856adf7d2..feff59d65 100644
  	}
  	return false;
 diff --git a/drbd/drbd_state.c b/drbd/drbd_state.c
-index 08a74f904..4fb33f87e 100644
+index ac4409197..655145975 100644
 --- a/drbd/drbd_state.c
 +++ b/drbd/drbd_state.c
-@@ -1641,7 +1641,7 @@ handshake_found:
+@@ -1654,7 +1654,7 @@ handshake_found:
  				return SS_TWO_PRIMARIES;
  			if (!fail_io[NEW]) {
  				idr_for_each_entry(&resource->devices, device, vnr) {
@@ -309,7 +309,7 @@ index 08a74f904..4fb33f87e 100644
  						return SS_PRIMARY_READER;
  					/*
  					 * One might be tempted to add "|| open_rw_cont" here.
-@@ -1668,7 +1668,7 @@ handshake_found:
+@@ -1681,7 +1681,7 @@ handshake_found:
  		     (disk_state[OLD] > D_DETACHING && disk_state[NEW] == D_DETACHING)))
  			return SS_IN_TRANSIENT_STATE;
  
@@ -318,7 +318,7 @@ index 08a74f904..4fb33f87e 100644
  		    !(resource->state_change_flags & CS_FS_IGN_OPENERS))
  			return SS_DEVICE_IN_USE;
  
-@@ -1700,8 +1700,7 @@ handshake_found:
+@@ -1713,8 +1713,7 @@ handshake_found:
  			return SS_NO_UP_TO_DATE_DISK;
  
  		/* Prevent detach or disconnect while held open read only */

--- a/SOURCES/0022-Fix-for-Revert-drbd-rework-autopromote.patch
+++ b/SOURCES/0022-Fix-for-Revert-drbd-rework-autopromote.patch
@@ -1,4 +1,4 @@
-From a979b8617a85ff8645996eb2f214672fe70c9229 Mon Sep 17 00:00:00 2001
+From ed1e59701e8afaa403087b4a817296dba21566d6 Mon Sep 17 00:00:00 2001
 From: Lars Ellenberg <lars.ellenberg@linbit.com>
 Date: Thu, 10 Oct 2024 19:01:26 +0200
 Subject: [PATCH] Fix for 'Revert "drbd: rework autopromote"'
@@ -62,22 +62,22 @@ index 4c57be0b8..d24cf9a63 100644
 +...
 +}
 diff --git a/drbd/drbd_int.h b/drbd/drbd_int.h
-index ebe1b38e5..20eb42a98 100644
+index 20bf0a259..0292eb22b 100644
 --- a/drbd/drbd_int.h
 +++ b/drbd/drbd_int.h
-@@ -1581,6 +1581,7 @@ struct drbd_device {
+@@ -1586,6 +1586,7 @@ struct drbd_device {
  
- 	struct drbd_bitmap *bitmap;
+ 	struct drbd_bitmap *bitmap; /* enclose accessing code in get_ldev() / put_ldev() */
  
 +	bool ro_cnt_is_write; /* we want to deal with mount --remount,rw somehow */
  	int open_rw_cnt, open_ro_cnt;
  	/* FIXME clean comments, restructure so it is more obvious which
  	 * members are protected by what */
 diff --git a/drbd/drbd_main.c b/drbd/drbd_main.c
-index 2a1e23c15..b03e69795 100644
+index 05503356c..7af78e29b 100644
 --- a/drbd/drbd_main.c
 +++ b/drbd/drbd_main.c
-@@ -2928,7 +2928,10 @@ void drbd_open_counts(struct drbd_resource *resource, int *rw_count_ptr, int *ro
+@@ -2950,7 +2950,10 @@ void drbd_open_counts(struct drbd_resource *resource, int *rw_count_ptr, int *ro
  	rcu_read_lock();
  	idr_for_each_entry(&resource->devices, device, vnr) {
  		rw_count += device->open_rw_cnt;
@@ -89,7 +89,7 @@ index 2a1e23c15..b03e69795 100644
  	}
  	rcu_read_unlock();
  	*rw_count_ptr = rw_count;
-@@ -3001,26 +3004,37 @@ static void drbd_release(struct gendisk *gd)
+@@ -3023,26 +3026,37 @@ static void drbd_release(struct gendisk *gd)
  	/* This is a workaround for kernels that do not pass in the fmode_t argument.*/
  	fmode_t mode = device->open_ro_cnt ? FMODE_READ : FMODE_WRITE;
  
@@ -140,10 +140,10 @@ index 2a1e23c15..b03e69795 100644
  
  	if (open_ro_cnt == 0)
 diff --git a/drbd/drbd_req.c b/drbd/drbd_req.c
-index feff59d65..b1e61da3c 100644
+index b03c22713..999c076e0 100644
 --- a/drbd/drbd_req.c
 +++ b/drbd/drbd_req.c
-@@ -2570,7 +2570,7 @@ static bool drbd_reject_write_early(struct drbd_device *device, struct bio *bio)
+@@ -2580,7 +2580,7 @@ static bool drbd_reject_write_early(struct drbd_device *device, struct bio *bio)
  		return true;
  	} else if (device->open_rw_cnt + device->open_ro_cnt == 0) {
  		drbd_err_ratelimit(device, "WRITE request, but open_cnt == 0!\n");
@@ -152,7 +152,7 @@ index feff59d65..b1e61da3c 100644
  		/*
  		 * If the resource was (temporarily, auto) promoted,
  		 * a remount,rw may have succeeded without marking the device
-@@ -2582,8 +2582,7 @@ static bool drbd_reject_write_early(struct drbd_device *device, struct bio *bio)
+@@ -2592,8 +2592,7 @@ static bool drbd_reject_write_early(struct drbd_device *device, struct bio *bio)
  		mutex_lock(&resource->open_release);
  		drbd_info(device, "open_ro_cnt:%d, implicitly promoted to writable\n",
  			device->open_ro_cnt);
@@ -163,10 +163,10 @@ index feff59d65..b1e61da3c 100644
  	}
  	return false;
 diff --git a/drbd/drbd_state.c b/drbd/drbd_state.c
-index 4fb33f87e..6dd761165 100644
+index 655145975..d8338aa25 100644
 --- a/drbd/drbd_state.c
 +++ b/drbd/drbd_state.c
-@@ -1641,7 +1641,7 @@ handshake_found:
+@@ -1654,7 +1654,7 @@ handshake_found:
  				return SS_TWO_PRIMARIES;
  			if (!fail_io[NEW]) {
  				idr_for_each_entry(&resource->devices, device, vnr) {
@@ -175,7 +175,7 @@ index 4fb33f87e..6dd761165 100644
  						return SS_PRIMARY_READER;
  					/*
  					 * One might be tempted to add "|| open_rw_cont" here.
-@@ -1668,7 +1668,8 @@ handshake_found:
+@@ -1681,7 +1681,8 @@ handshake_found:
  		     (disk_state[OLD] > D_DETACHING && disk_state[NEW] == D_DETACHING)))
  			return SS_IN_TRANSIENT_STATE;
  

--- a/SOURCES/0023-Fixup-for-recent-commit.patch
+++ b/SOURCES/0023-Fixup-for-recent-commit.patch
@@ -1,4 +1,4 @@
-From 0ada76df2c907b41a36e235691818edff1ceff63 Mon Sep 17 00:00:00 2001
+From ed8745cfdfe1341588e16dcf171a12e7bbd9b191 Mon Sep 17 00:00:00 2001
 From: Philipp Reisner <philipp.reisner@linbit.com>
 Date: Wed, 14 Jan 2026 11:06:00 +0100
 Subject: [PATCH] Fixup for recent commit 8f11218ce3758 ('drbd: fix an aspect
@@ -9,10 +9,10 @@ Subject: [PATCH] Fixup for recent commit 8f11218ce3758 ('drbd: fix an aspect
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drbd/drbd_receiver.c b/drbd/drbd_receiver.c
-index 65c67f0d7..e66fdda2a 100644
+index 7d1cc155b..47e04ca32 100644
 --- a/drbd/drbd_receiver.c
 +++ b/drbd/drbd_receiver.c
-@@ -761,7 +761,7 @@ static void apply_local_state_change(struct drbd_connection *connection, enum ao
+@@ -767,7 +767,7 @@ static void apply_local_state_change(struct drbd_connection *connection, enum ao
  			if (r == L_WF_BITMAP_T || r == L_SYNC_TARGET || r == L_PAUSED_SYNC_T)
  				__change_disk_state(device, D_OUTDATED);
  

--- a/SOURCES/drbd-9.2.16.tar.gz
+++ b/SOURCES/drbd-9.2.16.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d9f7fd5ed4a5527246e72eaaad16064e042265d127cf2c0a68a47de88b45f19c
-size 1908419

--- a/SOURCES/drbd-9.2.18.tar.gz
+++ b/SOURCES/drbd-9.2.18.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:944efa6a7b8ac6f27701668dd329d542fb95375b08ca5f17f00124e309fd1b26
+size 2164597

--- a/SOURCES/drbd.conf
+++ b/SOURCES/drbd.conf
@@ -1,0 +1,2 @@
+options drbd_transport_tcp keepcnt=2 keepidle=120 keepintvl=2
+options drbd max_parallel_resyncs=5

--- a/SPECS/kmod-drbd.spec
+++ b/SPECS/kmod-drbd.spec
@@ -1,7 +1,7 @@
 Name: kmod-drbd
 Summary: Kernel driver for DRBD
-Version: 9.2.16
-Release: 1.0%{?dist}
+Version: 9.2.18
+Release: 2.0%{?dist}
 
 # always require a suitable userland
 Requires: drbd-utils >= 9.27.0
@@ -32,17 +32,42 @@ BuildRequires: %kernel_module_package_buildreqs
 # on SMAPIv3 in order to be compatible with the current linbit design.
 #
 # Patches generated from this repo/branch:
-# https://github.com/LINBIT/drbd/tree/restore_exact_open_counts_9.2.16
-# with this command: "git format-patch drbd-9.2.16..HEAD^ --no-signature --no-numbered".
+# https://github.com/LINBIT/drbd/tree/restore_exact_open_counts_9.2.18-2
+# with this command: "git format-patch drbd-9.2.18..HEAD~2 --no-signature --no-numbered".
+# Dropping the 2 last patches:
+#   - Prepare drbd-9.2.18-xen.2
+#   - Prepare drbd-9.2.18-xen.1
+# because they don't include any useful info (versioning mostly).
+# Also manually dropping patch 0008: "debian: point to new drbd-dev mailing list",
+# because it's modifying debian packaging related files which doesn't exist in the release archive.
 #
 # The official tarballs to use can be found at this link: https://pkg.linbit.com/
 # Never use GitHub tarballs (https://github.com/LINBIT/drbd/tags), which don't work.
 # They are created automatically every time a tag is pushed to the repo by linbit.
 # Just for understanding purposes: working tarballs can be generated via "make tarball"
 # in the root folder of the DRBD project.
-Patch1001: 0001-Revert-drbd-rework-autopromote.patch
-Patch1002: 0002-Fix-for-Revert-drbd-rework-autopromote.patch
-Patch1003: 0003-Fixup-for-recent-commit.patch
+Patch1001: 0001-Revert-drbd-flush_send_buffer-send-error-should-resu.patch
+Patch1002: 0002-checkpatch-use-no-signoff-no-fixes-tag-for-merges.patch
+Patch1003: 0003-misc-add-prepare-commit-msg-script-to-add-signoff.patch
+Patch1004: 0004-containers-add-Ubuntu-Resolute.patch
+Patch1005: 0005-build-enable-fault-injection-using-ccflags-y.patch
+Patch1006: 0006-build-stamp-compat.h-against-include-config-auto.con.patch
+Patch1007: 0007-drbd-prefer-exact-IP-port-match-in-drbd_find_path_by.patch
+Patch1009: 0009-drbd-limit-number-of-volumes-resyncing-in-parallel.patch
+Patch1010: 0010-drbd-fix-AB-BA-deadlock-between-online-resize-and-AL.patch
+Patch1011: 0011-drbd-fix-list-corruption-when-freeing-peer_req-from-.patch
+Patch1012: 0012-drbd-distinguish-send_oos-list-membership-with-EE_ON.patch
+Patch1013: 0013-Revert-drbd-prefer-exact-IP-port-match-in-drbd_find_.patch
+Patch1014: 0014-drbd-pin-listener-across-dtt_wait_for_connect-to-fix.patch
+Patch1015: 0015-drbd-move-TCP-listener-wait-queue-to-tcp_transport.patch
+Patch1016: 0016-drbd-initialize-drbd_resources-list-head-statically.patch
+Patch1017: 0017-build-avoid-stdin-hang-when-kernel-.config-is-unavai.patch
+Patch1018: 0018-drbd-cancel_dagtag_dependent_requests-remove-interva.patch
+Patch1019: 0019-drbd-drop-double-dec_rs_pending-in-drbd_peer_resync_.patch
+Patch1020: 0020-drbd-fix-list-corruption-when-freeing-peer_req-from-.patch
+Patch1021: 0021-Revert-drbd-rework-autopromote.patch
+Patch1022: 0022-Fix-for-Revert-drbd-rework-autopromote.patch
+Patch1023: 0023-Fixup-for-recent-commit.patch
 
 # rpmbuild --with gcov to set GCOV_PROFILE=y for make
 %bcond_with gcov
@@ -87,9 +112,7 @@ for the DRBD core and various transports.
 %prep
 rm -f %{?my_tmp_files_to_be_removed_in_prep}
 %setup -q -n drbd-%{tarball_version}
-%patch1001 -p1
-%patch1002 -p1
-%patch1003 -p1
+%autopatch -p1
 
 %build
 make -C drbd %{_smp_mflags} all KDIR=/lib/modules/%{kernel_version}/build \
@@ -173,6 +196,11 @@ sed -i "s/\# \(global_filter\)[[:space:]]*=.*/\1 = [ \"r|^\/dev\/drbd.*|\" ]/g" 
 rm -rf %{buildroot}
 
 %changelog
+* Mon Jun 08 2026 Mathieu Labourier <mathieu.labourier@vates.tech> - 9.2.18-2.0
+- Update to upstream version 9.2.18 + upstream patches not part of an upstream release yet
+- Limit number of concurrent resyncs
+- Stability improvement and fixes
+
 * Fri Jan 23 2026 Ronan Abhamon <ronan.abhamon@vates.tech> - 9.2.16-1.0
 - Remove 0003-drbd-drbd_md_get_buffer-do-not-give-up-early.patch
 - Add 0003-Fixup-for-recent-commit.patch

--- a/SPECS/kmod-drbd.spec
+++ b/SPECS/kmod-drbd.spec
@@ -7,7 +7,9 @@ Release: 2.0%{?dist}
 Requires: drbd-utils >= 9.27.0
 
 %global tarball_version %(echo "%{version}" | sed -e "s,%{?dist}$,," -e "s,~,-,")
-Source: http://pkg.linbit.com/downloads/drbd/9/drbd-%{tarball_version}.tar.gz
+Source0: http://pkg.linbit.com/downloads/drbd/9/drbd-%{tarball_version}.tar.gz
+# XCP-ng: custom drbd configuration
+Source1: drbd.conf
 
 License: GPLv2+
 Group: System Environment/Kernel
@@ -152,6 +154,9 @@ while read -r mod path; do
 done > %{buildroot}/etc/depmod.d/drbd.conf
 install -D misc/SECURE-BOOT-KEY-linbit.com.der %{buildroot}/etc/pki/linbit/SECURE-BOOT-KEY-linbit.com.der
 
+# XCP-ng: custom drbd configuration
+install -D -m 644 %{SOURCE1} %{buildroot}%{_prefix}/lib/modprobe.d/drbd.conf
+
 %post
 if [ -e "/boot/System.map-%{kernel_version}" ]; then
     /usr/sbin/depmod -aeF "/boot/System.map-%{kernel_version}" "%{kernel_version}" > /dev/null || :
@@ -191,6 +196,8 @@ sed -i "s/\# \(global_filter\)[[:space:]]*=.*/\1 = [ \"r|^\/dev\/drbd.*|\" ]/g" 
 /etc/pki/linbit/SECURE-BOOT-KEY-linbit.com.der
 /lib/modules/%{kernel_version}/extra/drbd/*.ko
 /lib/modules/%{kernel_version}/extra/drbd/drbd-kernel-compat/handshake/*.ko
+# XCP-ng: custom drbd configuration
+%{_prefix}/lib/modprobe.d/drbd.conf
 
 %clean
 rm -rf %{buildroot}
@@ -200,6 +207,8 @@ rm -rf %{buildroot}
 - Update to upstream version 9.2.18 + upstream patches not part of an upstream release yet
 - Limit number of concurrent resyncs
 - Stability improvement and fixes
+- Add drbd.conf file in /usr/lib/modprobe.d (moved from xcp-ng-release-linstor)
+- Add max_parallel_sync options in drbd.conf
 
 * Fri Jan 23 2026 Ronan Abhamon <ronan.abhamon@vates.tech> - 9.2.16-1.0
 - Remove 0003-drbd-drbd_md_get_buffer-do-not-give-up-early.patch


### PR DESCRIPTION
### Main information

#### Work Item Reference

<!-- If this change is related to a Vates internal task or issue,
please provide a work item reference (e.g., XCPNG-12345), Otherwise,
remove this section and the next one. -->

XCPNG-3266

#### Related changes (optional)

<!--When several PRs are part of a single changeset, you can either fill
the form for each PR, or just once and link towards the PR with the filled
form. In the reference PR, the one with the form filled in, list all related
PRs.

You can also mention here constraints between PRs, if useful:
merge/build order, chained builds...-->

Related to PR https://github.com/xcp-ng-rpms/xcp-ng-release-linstor/pull/8

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

Updates DRBD to the latest 9.2.18 update, along with the patch that limits the number of resyncs in parallel. We have a memory leak in DRBD happening when doing resyncs, a massive number of simultaneous resyncs often caused the RAM to overload and cause OOM errors. This fix mitigates the issue by limiting the number of parallel resyncs, limiting the impact of the memory leak.

Also this PR takes the drbd.conf from xcp-ng-release-linstor.

There's no additional patch written specifically for our needs (even the patch that limits the number of resyncs, which is part of the upstream release) besides the previous 3:
```
0021-Revert-drbd-rework-autopromote.patch
0022-Fix-for-Revert-drbd-rework-autopromote.patch
0023-Fixup-for-recent-commit.patch
```

The reason why there is 20 additional patches is that we need the commit that limits the number of concurrent resync, and also the one that fixes a bug introduce by said commit, but that is not yet officially released as a package on their end (the release made for us is 9.2.18-2). So all patches that show up here besides the three ones made for us are currently upstream and will be part of the next release.

#### Release Target

- [x] We already defined a release target with the release team.
- [ ] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->

8.3-next

---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

Improve XOSTOR stabilty when evacuating/evicting an host.

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

A reboot is required for the changes to be effective.

#### Documentation update needed

- [ ] Yes
- [x] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->

We could eventually document how to change the number of parallel resyncs but that is overall a bad idea since the (positive) performance impact is limited but the risk gets higher if one would raise the parallel resync limit.

<!-- Add links to the documentation update PRs if/when they are created. -->

PR links: N/A.

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

Manual tests of the feature, if it does have an impact of the number of concurrent resyncs, if it can be tuned live during resyncs, and if the resyncs works properly. Sparse stability tests have been done. More rigorous stability tests must be done.

Since the drbd.conf file has been moved to this repo. Tests that it's properly changed when updating, and properly added and loaded before drbd when installing have been performed.

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

Evacuating an host, limiting the number of resources, standard usage of a XOSTOR SR (snapshots, backups, VM start, stop, etc.)

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

Standards operations are covered by the Linstor SR tests. As well as intra and cross pool migrations.

#### What tests have been or will be added to CI for this change? If none, explain why.

None. The resync limiting feature would be quite hard to test and would serve a limited interest since Linbit would theorically test the feature itself beforehand and that it is only specific to the internal works of Linstor and DRBD and doesn't affect the SMAPI or any other component. 

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [x] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->
